### PR TITLE
[feature] 여행조각 추가 기능 구현

### DIFF
--- a/src/main/java/umc/TripPiece/config/WebConfig.java
+++ b/src/main/java/umc/TripPiece/config/WebConfig.java
@@ -1,0 +1,24 @@
+package umc.TripPiece.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import umc.TripPiece.converter.OctetStreamReadMsgConverter;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private OctetStreamReadMsgConverter octetStreamReadMsgConverter;
+
+    @Autowired
+    public WebConfig(OctetStreamReadMsgConverter octetStreamReadMsgConverter) {
+        this.octetStreamReadMsgConverter = octetStreamReadMsgConverter;
+    }
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(octetStreamReadMsgConverter);
+    }
+}

--- a/src/main/java/umc/TripPiece/converter/OctetStreamReadMsgConverter.java
+++ b/src/main/java/umc/TripPiece/converter/OctetStreamReadMsgConverter.java
@@ -1,0 +1,34 @@
+package umc.TripPiece.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class OctetStreamReadMsgConverter extends AbstractJackson2HttpMessageConverter {
+    @Autowired
+    public OctetStreamReadMsgConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    // 기존 application/octet-stream 타입을 쓰기로 다루는 메시지 컨버터가 이미 존재 (ByteArrayHttpMessageConverter)
+    // 따라서 해당 컨버터는 쓰기 작업에는 이용하면 안됨
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/umc/TripPiece/converter/TravelConverter.java
+++ b/src/main/java/umc/TripPiece/converter/TravelConverter.java
@@ -1,0 +1,25 @@
+package umc.TripPiece.converter;
+
+import umc.TripPiece.domain.*;
+import umc.TripPiece.web.dto.request.TravelRequestDto;
+import umc.TripPiece.web.dto.response.TravelResponseDto;
+
+import java.time.LocalDate;
+
+public class TravelConverter {
+
+    public static TripPiece toTripPieceMemo(TravelRequestDto.MemoDto request) {
+        return TripPiece.builder()
+                .description(request.getDescription())
+                .build();
+    }
+
+    public static TravelResponseDto.CreateTripPieceResultDto toCreateTripPieceResultDto(TripPiece tripPiece) {
+        return TravelResponseDto.CreateTripPieceResultDto.builder()
+                .tripPieceId(tripPiece.getId())
+                .createdAt(LocalDate.now())
+                .build();
+    }
+
+
+}

--- a/src/main/java/umc/TripPiece/converter/TripPieceConverter.java
+++ b/src/main/java/umc/TripPiece/converter/TripPieceConverter.java
@@ -1,0 +1,31 @@
+package umc.TripPiece.converter;
+
+import umc.TripPiece.domain.Emoji;
+import umc.TripPiece.domain.Picture;
+import umc.TripPiece.domain.TripPiece;
+import umc.TripPiece.domain.Video;
+import umc.TripPiece.web.dto.request.TravelRequestDto;
+
+public class TripPieceConverter {
+
+    public static Emoji toTripPieceEmoji(String emoji, TripPiece tripPiece) {
+        return Emoji.builder()
+                .emoji(emoji)
+                .tripPiece(tripPiece)
+                .build();
+    }
+
+    public static Picture toTripPiecePicture(String pictureUrl, TripPiece tripPiece) {
+        return Picture.builder()
+                .pictureUrl(pictureUrl)
+                .tripPiece(tripPiece)
+                .build();
+    }
+
+    public static Video toTripPieceVideo(String videoUrl, TripPiece tripPiece) {
+        return Video.builder()
+                .videoUrl(videoUrl)
+                .tripPiece(tripPiece)
+                .build();
+    }
+}

--- a/src/main/java/umc/TripPiece/domain/Emoji.java
+++ b/src/main/java/umc/TripPiece/domain/Emoji.java
@@ -9,18 +9,17 @@ import umc.TripPiece.domain.common.BaseEntity;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Picture extends BaseEntity {
+public class Emoji extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
     @Column(unique = true)
-    private String pictureUrl;
+    private String emoji;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trip_piece_id")
     private TripPiece tripPiece;
-
 
 }

--- a/src/main/java/umc/TripPiece/domain/Like.java
+++ b/src/main/java/umc/TripPiece/domain/Like.java
@@ -16,8 +16,8 @@ public class Like {
     @JoinColumn(name = "user_id")
     private User user;
 
-   @ManyToOne(fetch = FetchType.LAZY)
-   @JoinColumn(name = "travel_id")
-   private Travel travel;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travel_id")
+    private Travel travel;
 
 }

--- a/src/main/java/umc/TripPiece/domain/Travel.java
+++ b/src/main/java/umc/TripPiece/domain/Travel.java
@@ -2,11 +2,8 @@ package umc.TripPiece.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import umc.TripPiece.domain.common.BaseEntity;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/umc/TripPiece/domain/TripPiece.java
+++ b/src/main/java/umc/TripPiece/domain/TripPiece.java
@@ -1,7 +1,7 @@
 package umc.TripPiece.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import umc.TripPiece.domain.common.BaseEntity;
 import umc.TripPiece.domain.enums.Category;
@@ -11,6 +11,9 @@ import java.util.List;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class TripPiece extends BaseEntity {
 
     @Id
@@ -24,7 +27,8 @@ public class TripPiece extends BaseEntity {
     @Column(nullable = false)
     private String description;
 
-    @Column(nullable = false)
+    @Column
+    @ColumnDefault("true")
     private Boolean travel_contain;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -34,4 +38,17 @@ public class TripPiece extends BaseEntity {
     @OneToMany(mappedBy = "tripPiece", cascade = CascadeType.ALL)
     private List<Picture> pictures = new ArrayList<>();
 
+    @OneToMany(mappedBy = "tripPiece", cascade = CascadeType.ALL)
+    private List<Video> videos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "tripPiece", cascade = CascadeType.ALL)
+    private List<Emoji> emojis = new ArrayList<>();
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public void setTravel(Travel travel) {
+        this.travel = travel;
+    }
 }

--- a/src/main/java/umc/TripPiece/domain/Video.java
+++ b/src/main/java/umc/TripPiece/domain/Video.java
@@ -1,11 +1,14 @@
 package umc.TripPiece.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 import umc.TripPiece.domain.common.BaseEntity;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Video extends BaseEntity {
 
     @Id
@@ -15,7 +18,7 @@ public class Video extends BaseEntity {
     @Column(unique = true)
     private String videoUrl;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trip_piece_id")
     private TripPiece tripPiece;
 

--- a/src/main/java/umc/TripPiece/domain/enums/Category.java
+++ b/src/main/java/umc/TripPiece/domain/enums/Category.java
@@ -1,7 +1,0 @@
-package umc.TripPiece.domain.enums;
-
-public enum Category {
-    MEMO,
-    PICTURE,
-    VIDEO
-}

--- a/src/main/java/umc/TripPiece/repository/EmojiRepository.java
+++ b/src/main/java/umc/TripPiece/repository/EmojiRepository.java
@@ -1,0 +1,7 @@
+package umc.TripPiece.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.TripPiece.domain.Emoji;
+
+public interface EmojiRepository extends JpaRepository<Emoji, Long> {
+}

--- a/src/main/java/umc/TripPiece/repository/PictureRepository.java
+++ b/src/main/java/umc/TripPiece/repository/PictureRepository.java
@@ -1,0 +1,7 @@
+package umc.TripPiece.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.TripPiece.domain.Picture;
+
+public interface PictureRepository extends JpaRepository<Picture, Long> {
+}

--- a/src/main/java/umc/TripPiece/repository/TripPieceRepository.java
+++ b/src/main/java/umc/TripPiece/repository/TripPieceRepository.java
@@ -1,0 +1,7 @@
+package umc.TripPiece.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.TripPiece.domain.TripPiece;
+
+public interface TripPieceRepository extends JpaRepository<TripPiece, Long> {
+}

--- a/src/main/java/umc/TripPiece/repository/VideoRepository.java
+++ b/src/main/java/umc/TripPiece/repository/VideoRepository.java
@@ -1,0 +1,7 @@
+package umc.TripPiece.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.TripPiece.domain.Video;
+
+public interface VideoRepository extends JpaRepository<Video, Long> {
+}

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -3,12 +3,13 @@ package umc.TripPiece.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.TripPiece.domain.City;
-import umc.TripPiece.domain.Country;
-import umc.TripPiece.domain.Travel;
-import umc.TripPiece.repository.CityRepository;
-import umc.TripPiece.repository.CountryRepository;
-import umc.TripPiece.repository.TravelRepository;
+import org.springframework.web.multipart.MultipartFile;
+import umc.TripPiece.converter.TravelConverter;
+import umc.TripPiece.converter.TripPieceConverter;
+import umc.TripPiece.domain.*;
+import umc.TripPiece.domain.enums.Category;
+import umc.TripPiece.repository.*;
+import umc.TripPiece.web.dto.request.TravelRequestDto;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +21,10 @@ public class TravelService {
     private final CityRepository cityRepository;
     private final CountryRepository countryRepository;
     private final TravelRepository travelRepository;
+    private final TripPieceRepository tripPieceRepository;
+    private final EmojiRepository emojiRepository;
+    private final PictureRepository pictureRepository;
+    private final VideoRepository videoRepository;
 
     public List<Travel> searchByKeyword(String keyword) {
         List<City> cities = cityRepository.findByNameContainingIgnoreCase(keyword);
@@ -35,4 +40,97 @@ public class TravelService {
         }
         return travels;
     }
+
+
+    @Transactional
+    public TripPiece createMemo(Long travelId, TravelRequestDto.MemoDto request) {
+
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        newTripPiece.setTravel(travelRepository.findById(travelId).get());
+
+        return tripPieceRepository.save(newTripPiece);
+    }
+
+    @Transactional
+    public TripPiece createEmoji(Long travelId, String emoji, TravelRequestDto.MemoDto request) {
+
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        newTripPiece.setTravel(travelRepository.findById(travelId).get());
+        newTripPiece.setCategory(Category.EMOJI);
+
+        Emoji newEmoji = TripPieceConverter.toTripPieceEmoji(emoji, newTripPiece);
+
+        emojiRepository.save(newEmoji);
+
+        return tripPieceRepository.save(newTripPiece);
+    }
+
+    @Transactional
+    public TripPiece createPicture(Long travelId, MultipartFile picture, TravelRequestDto.MemoDto request) {
+
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        newTripPiece.setTravel(travelRepository.findById(travelId).get());
+        newTripPiece.setCategory(Category.PICTURE);
+
+        String pictureUrl = null;
+
+        Picture newPicture = TripPieceConverter.toTripPiecePicture(pictureUrl, newTripPiece);
+
+        pictureRepository.save(newPicture);
+
+        return tripPieceRepository.save(newTripPiece);
+
+    }
+
+    @Transactional
+    public TripPiece createSelfie(Long travelId, MultipartFile picture, TravelRequestDto.MemoDto request) {
+
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        newTripPiece.setTravel(travelRepository.findById(travelId).get());
+        newTripPiece.setCategory(Category.SELFIE);
+
+        String pictureUrl = null;
+
+        Picture newPicture = TripPieceConverter.toTripPiecePicture(pictureUrl, newTripPiece);
+
+        pictureRepository.save(newPicture);
+
+        return tripPieceRepository.save(newTripPiece);
+
+    }
+
+    @Transactional
+    public TripPiece createVideo(Long travelId, MultipartFile video, TravelRequestDto.MemoDto request) {
+
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        newTripPiece.setTravel(travelRepository.findById(travelId).get());
+        newTripPiece.setCategory(Category.VIDEO);
+
+        String videoUrl = null;
+
+        Video newVideo = TripPieceConverter.toTripPieceVideo(videoUrl, newTripPiece);
+
+        videoRepository.save(newVideo);
+
+        return tripPieceRepository.save(newTripPiece);
+
+    }
+
+    @Transactional
+    public TripPiece createWhere(Long travelId, MultipartFile video, TravelRequestDto.MemoDto request) {
+
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        newTripPiece.setTravel(travelRepository.findById(travelId).get());
+        newTripPiece.setCategory(Category.WHERE);
+
+        String videoUrl = null;
+
+        Video newVideo = TripPieceConverter.toTripPieceVideo(videoUrl, newTripPiece);
+
+        videoRepository.save(newVideo);
+
+        return tripPieceRepository.save(newTripPiece);
+
+    }
+
 }

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -1,11 +1,19 @@
 package umc.TripPiece.web.controller;
 
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import umc.TripPiece.converter.TravelConverter;
+import umc.TripPiece.domain.Picture;
 import umc.TripPiece.domain.Travel;
+import umc.TripPiece.domain.TripPiece;
+import umc.TripPiece.payload.ApiResponse;
 import umc.TripPiece.service.TravelService;
+import umc.TripPiece.web.dto.request.TravelRequestDto;
+import umc.TripPiece.web.dto.response.TravelResponseDto;
 
 import java.util.List;
 
@@ -19,4 +27,48 @@ public class TravelController {
     public List<Travel> searchByKeyword(@RequestParam String keyword) {
         return travelService.searchByKeyword(keyword);
     }
+
+    @PostMapping("/mytravels/{travelId}/memo")
+    @Operation(summary = "메모 기록 API", description = "특정 여행기에서의 여행조각 추가")
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceMemo(@RequestBody TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId){
+        TripPiece tripPiece = travelService.createMemo(travelId, request);
+        return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
+    }
+
+    @PostMapping("/mytravels/{travelId}/emoji")
+    @Operation(summary = "이모지 기록 API", description = "특정 여행기에서의 여행조각 추가")
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceEmoji(@RequestBody TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam(name = "emoji") String emoji){
+        TripPiece tripPiece = travelService.createEmoji(travelId, emoji, request);
+        return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
+    }
+
+    @PostMapping(value = "/mytravels/{travelId}/picture", consumes = "multipart/form-data")
+    @Operation(summary = "사진 기록 API", description = "특정 여행기에서의 여행조각 추가")
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPiecePicture(@RequestPart TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart MultipartFile photo){
+        TripPiece tripPiece = travelService.createPicture(travelId, photo, request);
+        return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
+    }
+
+    @PostMapping(value = "/mytravels/{travelId}/selfie", consumes = "multipart/form-data")
+    @Operation(summary = "셀카 기록 API", description = "특정 여행기에서의 여행조각 추가")
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceSelfie(@RequestPart TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart MultipartFile photo){
+        TripPiece tripPiece = travelService.createSelfie(travelId, photo, request);
+        return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
+    }
+
+    @PostMapping(value = "/mytravels/{travelId}/video", consumes = "multipart/form-data")
+    @Operation(summary = "비디오 기록 API", description = "특정 여행기에서의 여행조각 추가")
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceVideo(@RequestPart TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart MultipartFile video){
+        TripPiece tripPiece = travelService.createVideo(travelId, video, request);
+        return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
+    }
+
+    @PostMapping(value = "/mytravels/{travelId}/where", consumes = "multipart/form-data")
+    @Operation(summary = "'지금 어디에 있나요?' 카테고리 기록 API", description = "특정 여행기에서의 여행조각 추가")
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceWhere(@RequestPart TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart MultipartFile video){
+        TripPiece tripPiece = travelService.createWhere(travelId, video, request);
+        return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
+    }
+
+
 }

--- a/src/main/java/umc/TripPiece/web/dto/request/TravelRequestDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/request/TravelRequestDto.java
@@ -1,0 +1,15 @@
+package umc.TripPiece.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class TravelRequestDto {
+
+    @Getter
+    public static class MemoDto {
+
+        @NotBlank
+        String description;
+    }
+
+}

--- a/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
@@ -1,0 +1,23 @@
+package umc.TripPiece.web.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.TripPiece.domain.enums.Category;
+
+import java.time.LocalDate;
+
+public class TravelResponseDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateTripPieceResultDto {
+        Long tripPieceId;
+        LocalDate createdAt;
+    }
+
+
+}


### PR DESCRIPTION
## 연관 이슈

#7 

<br/>

## 개요

여행조각 추가 기능 구현하였습니다.
1. 메모 - 기본 메모 추가/이모지
2. 사진 - 기본 사진 추가/셀카
3. 동영상 - 기본 동영상 추가/지금 어디에 있는지?
Swagger에서 잘 돌아가는거 확인되었습니다. 

흠.. 좀 기능 단위로 commit 하려다보니 추가된게 좀 많아요

<br/>

## ✅ 작업 내용

- [x] 카테고리 별로 구분하기 위해 엔티티 구성 변경 + Emoji 엔티티 추가
- [x] 사진/동영상 업로드 기능을 위한 class 추가 - OctetStreamReadMsgConverter, WebConfig
- [x] 각 엔티티 별 repository 추가
- [x] TravelController에 POST 기능 여러 개 추가
- [x] TravelRequestDto, TravelResponseDto, TripPieceConverter, TravelConverter 추가

<br/>

### 📝 논의사항

1. 이모지/사진은 아직 단일로 밖에 보내지 못해서 추후에 구현 예정
2. 아직 S3와 연결되지 않음 추후에 연결 예정
3. 각 사진/동영상 별로 Uuid(일련번호) 생성되게 할 예정(동일한 파일 이름이 있을 수 있으므로)
