### PR TITLE
[feature] 회원가입 API 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.security:spring-security-crypto'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/umc/TripPiece/TripPieceApplication.java
+++ b/src/main/java/umc/TripPiece/TripPieceApplication.java
@@ -2,9 +2,10 @@ package umc.TripPiece;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableJpaAuditing
 public class TripPieceApplication {
 

--- a/src/main/java/umc/TripPiece/config/SecurityConfig.java
+++ b/src/main/java/umc/TripPiece/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package umc.TripPiece.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/umc/TripPiece/converter/UserConverter.java
+++ b/src/main/java/umc/TripPiece/converter/UserConverter.java
@@ -1,0 +1,54 @@
+package umc.TripPiece.converter;
+
+import umc.TripPiece.domain.User;
+import umc.TripPiece.domain.enums.Gender;
+import umc.TripPiece.domain.enums.UserMethod;
+import umc.TripPiece.web.dto.request.UserRequestDto;
+import umc.TripPiece.web.dto.response.UserResponseDto;
+
+import java.time.LocalDateTime;
+
+public class UserConverter {
+
+    public static UserResponseDto.SignUpResultDto toSignUpResultDto(User user){
+        return UserResponseDto.SignUpResultDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .gender(user.getGender())
+                .birth(user.getBirth())
+                .profile_img(user.getProfile_img())
+                .country(user.getCountry())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static User toUser(UserRequestDto.SignUpDto request, String hashedPassword) {
+
+        Gender gender = null;
+
+        switch (request.getGender()){
+            case MALE:
+                gender = Gender.MALE;
+                break;
+            case FEMALE:
+                gender = Gender.FEMALE;
+                break;
+        }
+
+        return User.builder()
+                .name(request.getName())
+                .email(request.getEmail())
+                .password(hashedPassword)
+                .nickname(request.getNickname())
+                .gender(gender)
+                .birth(request.getBirth())
+                .profile_img(request.getProfileImg())
+                .country(request.getCountry())
+                .gps_consent(true) // 고정값 설정
+                .method(UserMethod.GENERAL) // 고정값 설정
+                .is_public(true) // 고정값 설정
+                .build();
+    }
+}

--- a/src/main/java/umc/TripPiece/domain/User.java
+++ b/src/main/java/umc/TripPiece/domain/User.java
@@ -1,14 +1,16 @@
 package umc.TripPiece.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import umc.TripPiece.domain.common.BaseEntity;
+import umc.TripPiece.domain.enums.Gender;
+import umc.TripPiece.domain.enums.UserMethod;
 
 @Entity
 @Getter
-@Setter
-
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,14 +27,15 @@ public class User extends BaseEntity {
     private String password;
 
     @Column(nullable = false, length = 20)
-    private String phone;
-
-    @Column(nullable = false, length = 20)
     private String nickname;
 
-    @Column(nullable = false, length = 20)
-    private String gender;
+    @Column(nullable = false, length = 10)
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
 
+    @Column(nullable = false, length = 20)
+    private String birth;
+    
     @Column
     private String profile_img;
 
@@ -43,7 +46,8 @@ public class User extends BaseEntity {
     private Boolean gps_consent;
 
     @Column(nullable = false, length = 10)
-    private String method;
+    @Enumerated(EnumType.STRING)
+    private UserMethod method;
 
     @Column(nullable = false)
     private Boolean is_public;

--- a/src/main/java/umc/TripPiece/domain/enums/Gender.java
+++ b/src/main/java/umc/TripPiece/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package umc.TripPiece.domain.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/umc/TripPiece/domain/enums/UserMethod.java
+++ b/src/main/java/umc/TripPiece/domain/enums/UserMethod.java
@@ -1,0 +1,5 @@
+package umc.TripPiece.domain.enums;
+
+public enum UserMethod {
+    GENERAL, KAKAO
+}

--- a/src/main/java/umc/TripPiece/payload/ApiResponse.java
+++ b/src/main/java/umc/TripPiece/payload/ApiResponse.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import umc.TripPiece.payload.code.BaseCode;
+import umc.TripPiece.payload.code.status.SuccessStatus;
 
 @Getter
 @AllArgsConstructor
@@ -19,15 +21,15 @@ public class ApiResponse<T> {
     private T result;
 
 
-    // 성공한 경우 응답 생성
+//     성공한 경우 응답 생성
 
-//    public static <T> ApiResponse<T> onSuccess(T result){
-//        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
-//    }
-//
-//    public static <T> ApiResponse<T> of(BaseCode code, T result){
-    //        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
-//    }
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
 
 
     // 실패한 경우 응답 생성

--- a/src/main/java/umc/TripPiece/repository/UserRepository.java
+++ b/src/main/java/umc/TripPiece/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package umc.TripPiece.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.TripPiece.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByNickname(String nickname);
+}

--- a/src/main/java/umc/TripPiece/service/UserService.java
+++ b/src/main/java/umc/TripPiece/service/UserService.java
@@ -1,0 +1,8 @@
+package umc.TripPiece.service;
+
+import umc.TripPiece.domain.User;
+import umc.TripPiece.web.dto.request.UserRequestDto;
+
+public interface UserService {
+    User signUp(UserRequestDto.SignUpDto request);
+}

--- a/src/main/java/umc/TripPiece/service/UserServiceImpl.java
+++ b/src/main/java/umc/TripPiece/service/UserServiceImpl.java
@@ -1,0 +1,41 @@
+package umc.TripPiece.service;
+
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import umc.TripPiece.converter.UserConverter;
+import umc.TripPiece.domain.User;
+import umc.TripPiece.repository.UserRepository;
+import umc.TripPiece.web.dto.request.UserRequestDto;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements  UserService{
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public User signUp(@Valid UserRequestDto.SignUpDto request) {
+
+
+        // 이메일 중복 확인
+        userRepository.findByEmail(request.getEmail()).ifPresent(user -> {
+//            throw new BaseException("이미 사용 중인 이메일입니다.");
+        });
+
+        // 닉네임 중복 확인
+        userRepository.findByNickname(request.getNickname()).ifPresent(user -> {
+//            throw new BaseException("이미 사용 중인 닉네임입니다.");
+        });
+
+        // 비밀번호 암호화
+        String hashedPassword = passwordEncoder.encode(request.getPassword());
+
+        User newUser = UserConverter.toUser(request, hashedPassword);
+        return userRepository.save(newUser);
+    }
+}

--- a/src/main/java/umc/TripPiece/web/controller/UserController.java
+++ b/src/main/java/umc/TripPiece/web/controller/UserController.java
@@ -1,0 +1,37 @@
+package umc.TripPiece.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.TripPiece.converter.UserConverter;
+import umc.TripPiece.domain.User;
+import umc.TripPiece.payload.ApiResponse;
+import umc.TripPiece.service.UserService;
+import umc.TripPiece.web.dto.request.UserRequestDto;
+import umc.TripPiece.web.dto.response.UserResponseDto;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+
+    private final UserService userService;
+//    private final JWTUtul jwtUtul;
+
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입 API",
+    description = "회원가입 API 구현")
+    public ApiResponse<UserResponseDto.SignUpResultDto> signUp(@RequestBody @Valid UserRequestDto.SignUpDto request) {
+        User user = userService.signUp(request);
+        return ApiResponse.onSuccess(UserConverter.toSignUpResultDto(user));
+    }
+}

--- a/src/main/java/umc/TripPiece/web/dto/request/UserRequestDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/request/UserRequestDto.java
@@ -1,0 +1,53 @@
+package umc.TripPiece.web.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.TripPiece.domain.enums.Gender;
+
+public class UserRequestDto {
+
+    /* 회원가입 */
+    @Getter
+    @NoArgsConstructor
+    public static class SignUpDto {
+
+        @NotBlank(message = "이름은 필수 입력 항목입니다.")
+        @Size(min = 2, max = 10, message = "이름은 2자에서 10자 사이여야 합니다.")
+        private String name;
+
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        @Email(message = "유효한 이메일 주소여야 합니다.")
+        private String email;
+
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,15}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8자에서 15자 사이여야 합니다."
+        )
+        private String password;
+
+        @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자에서 10자 사이여야 합니다.")
+        private String nickname;
+
+        private Gender gender;
+        private String birth;
+        private String profileImg;
+
+        @NotBlank(message = "국가는 필수 입력 항목입니다.")
+        private String country;
+
+    }
+
+    /* 로그인 */
+    @Getter
+    public static class LoginDto {
+        String email;
+        String password;
+    }
+
+}

--- a/src/main/java/umc/TripPiece/web/dto/response/UserResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/UserResponseDto.java
@@ -1,0 +1,41 @@
+package umc.TripPiece.web.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.TripPiece.domain.enums.Gender;
+
+import java.time.LocalDateTime;
+
+public class UserResponseDto {
+    /* 회원가입 */
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SignUpResultDto {
+        Long id;
+        String name;
+        String email;
+        String nickname;
+        Gender gender;
+        String birth;
+        String profile_img;
+        String country;
+        LocalDateTime createdAt;
+
+    }
+
+    /* 로그인 */
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class LoginResultDto {
+        Long id;
+        String email;
+        String name;
+        LocalDateTime createdAt;
+        private final String token;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 연관 이슈
#5

<br/>

## 개요
회원가입 API

<br/>

## ✅ 작업 내용
- [x] Gender, UserMethod(일반, 카카오) enum 추가
- [x] 회원가입 DTO 및 Controller, Service, Converter 추가
- [x] 로그인 DTO 작성
- [x] 비밀번호 암호화를 위한 security 설정 (SecurityConfig)

- Swagger 응답 성공
![swagger_회원가입_테스트(2)](https://github.com/user-attachments/assets/5a82f6d2-ee62-42fc-bdf1-4b49c6b6dff3)

- ex) 400 Error (유효하지 않은 이메일)
![image](https://github.com/user-attachments/assets/f156dcd1-c47f-4e59-ba30-d003e197ba37)

<br/>

## 📝 논의사항
- 프로필 이미지 S3 연동 필요
- BaseException 추가(?)
- 유효성 검사는 잘 반영되었는데, Response로 message가 반영이 안되어서 이 부분 추가하겠습니다!
<br/>

