### PR TITLE
[feature] 이모지, 글자수 제한 제약조건 구현

### DIFF
--- a/src/main/java/umc/TripPiece/domain/Emoji.java
+++ b/src/main/java/umc/TripPiece/domain/Emoji.java
@@ -15,7 +15,7 @@ public class Emoji extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
-    @Column(unique = true)
+    @Column
     private String emoji;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/TripPiece/payload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/TripPiece/payload/code/status/ErrorStatus.java
@@ -19,7 +19,15 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // s3 관련 오류
     PICTURE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "PICTURE400", "이미지의 확장자가 잘못되었습니다."),
-    VIDEO_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "VIDEO400", "동영상의 확장자가 잘못되었습니다.");
+    VIDEO_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "VIDEO400", "동영상의 확장자가 잘못되었습니다."),
+
+    // 이모지 오류
+    EMOJI_NUMBER_ERROR(HttpStatus.BAD_REQUEST, "EMOJI400", "이모지의 갯수는 4개이여야 합니다."),
+    EMOJI_INPUT_ERROR(HttpStatus.BAD_REQUEST, "EMOJI401", "이모지가 아닌 입력이 있습니다."),
+
+    // 글자 수 오류
+    TEXT_LENGTH_30_ERROR(HttpStatus.BAD_REQUEST, "TEXT400", "글자 수가 30자를 초과하였습니다."),
+    TEXT_LENGTH_100_ERROR(HttpStatus.BAD_REQUEST, "TEXT401", "글자 수가 100자를 초과하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/TripPiece/payload/exception/handler/EmojiHandler.java
+++ b/src/main/java/umc/TripPiece/payload/exception/handler/EmojiHandler.java
@@ -1,0 +1,8 @@
+package umc.TripPiece.payload.exception.handler;
+
+import umc.TripPiece.payload.code.BaseErrorCode;
+import umc.TripPiece.payload.exception.GeneralException;
+
+public class EmojiHandler extends GeneralException {
+    public EmojiHandler(BaseErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -61,15 +61,16 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createEmoji(Long travelId, String emoji, TravelRequestDto.MemoDto request) {
+    public TripPiece createEmoji(Long travelId, List<String> emojis, TravelRequestDto.MemoDto request) {
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
         newTripPiece.setCategory(Category.EMOJI);
 
-        Emoji newEmoji = TripPieceConverter.toTripPieceEmoji(emoji, newTripPiece);
-
-        emojiRepository.save(newEmoji);
+        for(String emoji : emojis) {
+            Emoji newEmoji = TripPieceConverter.toTripPieceEmoji(emoji, newTripPiece);
+            emojiRepository.save(newEmoji);
+        }
 
         return tripPieceRepository.save(newTripPiece);
     }

--- a/src/main/java/umc/TripPiece/validation/annotation/CheckEmoji.java
+++ b/src/main/java/umc/TripPiece/validation/annotation/CheckEmoji.java
@@ -1,0 +1,19 @@
+package umc.TripPiece.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.TripPiece.validation.validator.CheckEmojiNumValidator;
+import umc.TripPiece.validation.validator.CheckEmojiValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CheckEmojiValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckEmoji {
+
+    String message() default "비정상적인 입력: 이모지가 아닙니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/TripPiece/validation/annotation/CheckEmojiNum.java
+++ b/src/main/java/umc/TripPiece/validation/annotation/CheckEmojiNum.java
@@ -1,0 +1,18 @@
+package umc.TripPiece.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.TripPiece.validation.validator.CheckEmojiNumValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CheckEmojiNumValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckEmojiNum {
+
+    String message() default "이모지의 갯수는 4개여야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/TripPiece/validation/annotation/TextLength100.java
+++ b/src/main/java/umc/TripPiece/validation/annotation/TextLength100.java
@@ -1,0 +1,19 @@
+package umc.TripPiece.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.TripPiece.validation.validator.CheckEmojiValidator;
+import umc.TripPiece.validation.validator.TextLength100Validator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = TextLength100Validator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TextLength100 {
+
+    String message() default "글자 수 100자 초과 입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/TripPiece/validation/annotation/TextLength30.java
+++ b/src/main/java/umc/TripPiece/validation/annotation/TextLength30.java
@@ -1,0 +1,19 @@
+package umc.TripPiece.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.TripPiece.validation.validator.CheckEmojiValidator;
+import umc.TripPiece.validation.validator.TextLength30Validator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = TextLength30Validator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TextLength30 {
+
+    String message() default "글자 수 30자 초과 입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/TripPiece/validation/validator/CheckEmojiNumValidator.java
+++ b/src/main/java/umc/TripPiece/validation/validator/CheckEmojiNumValidator.java
@@ -1,0 +1,32 @@
+package umc.TripPiece.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.TripPiece.payload.code.status.ErrorStatus;
+import umc.TripPiece.validation.annotation.CheckEmojiNum;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CheckEmojiNumValidator implements ConstraintValidator<CheckEmojiNum, List<String>> {
+
+    @Override
+    public void initialize(CheckEmojiNum constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<String> emojis, ConstraintValidatorContext context) {
+        boolean isValid = emojis.size() == 4;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.EMOJI_NUMBER_ERROR.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/umc/TripPiece/validation/validator/CheckEmojiValidator.java
+++ b/src/main/java/umc/TripPiece/validation/validator/CheckEmojiValidator.java
@@ -1,0 +1,45 @@
+package umc.TripPiece.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.TripPiece.payload.code.status.ErrorStatus;
+import umc.TripPiece.validation.annotation.CheckEmoji;
+import umc.TripPiece.validation.annotation.CheckEmojiNum;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+@RequiredArgsConstructor
+public class CheckEmojiValidator implements ConstraintValidator<CheckEmoji, List<String>> {
+
+    @Override
+    public void initialize(CheckEmoji constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<String> emojis, ConstraintValidatorContext context) {
+        boolean isValid = true;
+
+        for(String emoji : emojis) {
+            Pattern rex = Pattern.compile("[\\x{10000}-\\x{10ffff}\ud800-\udfff]");
+            Matcher rexMatcher = rex.matcher(emoji);
+
+            if(!rexMatcher.find()) {
+                isValid = false;
+                break;
+            }
+        }
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.EMOJI_NUMBER_ERROR.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/umc/TripPiece/validation/validator/TextLength100Validator.java
+++ b/src/main/java/umc/TripPiece/validation/validator/TextLength100Validator.java
@@ -1,0 +1,32 @@
+package umc.TripPiece.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.TripPiece.payload.code.status.ErrorStatus;
+import umc.TripPiece.validation.annotation.TextLength100;
+import umc.TripPiece.validation.annotation.TextLength30;
+import umc.TripPiece.web.dto.request.TravelRequestDto;
+
+@Component
+@RequiredArgsConstructor
+public class TextLength100Validator implements ConstraintValidator<TextLength100, TravelRequestDto.MemoDto> {
+
+    @Override
+    public void initialize(TextLength100 constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(TravelRequestDto.MemoDto request, ConstraintValidatorContext context) {
+        boolean isValid = request.getDescription().length() <= 100;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.TEXT_LENGTH_100_ERROR.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/umc/TripPiece/validation/validator/TextLength30Validator.java
+++ b/src/main/java/umc/TripPiece/validation/validator/TextLength30Validator.java
@@ -1,0 +1,36 @@
+package umc.TripPiece.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.TripPiece.payload.code.status.ErrorStatus;
+import umc.TripPiece.validation.annotation.CheckEmoji;
+import umc.TripPiece.validation.annotation.TextLength30;
+import umc.TripPiece.web.dto.request.TravelRequestDto;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+@RequiredArgsConstructor
+public class TextLength30Validator implements ConstraintValidator<TextLength30, TravelRequestDto.MemoDto> {
+
+    @Override
+    public void initialize(TextLength30 constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(TravelRequestDto.MemoDto request, ConstraintValidatorContext context) {
+        boolean isValid = request.getDescription().length() <= 30;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.TEXT_LENGTH_30_ERROR.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -2,16 +2,18 @@ package umc.TripPiece.web.controller;
 
 
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.TripPiece.converter.TravelConverter;
-import umc.TripPiece.domain.Picture;
 import umc.TripPiece.domain.Travel;
 import umc.TripPiece.domain.TripPiece;
 import umc.TripPiece.payload.ApiResponse;
 import umc.TripPiece.service.TravelService;
+import umc.TripPiece.validation.annotation.CheckEmoji;
+import umc.TripPiece.validation.annotation.CheckEmojiNum;
+import umc.TripPiece.validation.annotation.TextLength100;
+import umc.TripPiece.validation.annotation.TextLength30;
 import umc.TripPiece.web.dto.request.TravelRequestDto;
 import umc.TripPiece.web.dto.response.TravelResponseDto;
 
@@ -50,42 +52,42 @@ public class TravelController {
 
     @PostMapping("/mytravels/{travelId}/memo")
     @Operation(summary = "메모 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceMemo(@RequestBody TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId){
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceMemo(@RequestBody @TextLength100 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId){
         TripPiece tripPiece = travelService.createMemo(travelId, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping("/mytravels/{travelId}/emoji")
     @Operation(summary = "이모지 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceEmoji(@RequestBody TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam(name = "emoji") String emoji){
-        TripPiece tripPiece = travelService.createEmoji(travelId, emoji, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceEmoji(@RequestBody @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam(name = "emojis") @CheckEmoji @CheckEmojiNum List<String> emojis){
+        TripPiece tripPiece = travelService.createEmoji(travelId, emojis, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/picture", consumes = "multipart/form-data")
     @Operation(summary = "사진 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPiecePicture(@RequestPart("memo") TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("photos") List<MultipartFile> photos){
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPiecePicture(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("photos") List<MultipartFile> photos){
         TripPiece tripPiece = travelService.createPicture(travelId, photos, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/selfie", consumes = "multipart/form-data")
     @Operation(summary = "셀카 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceSelfie(@RequestPart("memo") TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("photo") MultipartFile photo){
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceSelfie(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("photo") MultipartFile photo){
         TripPiece tripPiece = travelService.createSelfie(travelId, photo, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/video", consumes = "multipart/form-data")
     @Operation(summary = "비디오 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceVideo(@RequestPart("memo") TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("video") MultipartFile video){
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceVideo(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("video") MultipartFile video){
         TripPiece tripPiece = travelService.createVideo(travelId, video, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/where", consumes = "multipart/form-data")
     @Operation(summary = "'지금 어디에 있나요?' 카테고리 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceWhere(@RequestPart("memo") TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("video") MultipartFile video){
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceWhere(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("video") MultipartFile video){
         TripPiece tripPiece = travelService.createWhere(travelId, video, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }


### PR DESCRIPTION
## 연관 이슈

close #7 

<br/>

## 개요

1. 이모지가 아닌 값이 올 때
2. 이모지가 4개가 아닐 때
3. 글자수 제한을 넘겼을 때

검증 구현 완료했습니다.

<br/>

## ✅ 작업 내용

- [x] 글자 수 100자 제한
<img width="792" alt="image" src="https://github.com/user-attachments/assets/8a6ff920-f7c7-4dfb-92b5-5976c8943657">
<img width="781" alt="image" src="https://github.com/user-attachments/assets/8af8911e-e2ad-4fb0-9806-2d4f8c3d8e94">

- [x] 글자 수 30자 제한
<img width="787" alt="image" src="https://github.com/user-attachments/assets/189b667b-f344-4235-8825-5684ceb4248d">
<img width="784" alt="image" src="https://github.com/user-attachments/assets/ae01647b-d963-4b24-ac4e-6963767ab1fe">

- [x] 이모지 아닌 값이 올 때
<img width="791" alt="image" src="https://github.com/user-attachments/assets/cc5be0cc-7a6e-4410-89bb-3c1e2ac9f2a8">
<img width="783" alt="image" src="https://github.com/user-attachments/assets/fc321b13-3c20-4d60-9283-f772ab816702">

- [x] 이모지 4개가 아닐 때
<img width="786" alt="image" src="https://github.com/user-attachments/assets/3b383db1-5ef7-42dd-9424-7f814b8c575a">
<img width="783" alt="image" src="https://github.com/user-attachments/assets/20705b7e-1f8e-4685-b0b8-b4eda76f9a2e">

- [x] 이모지 정상 작동
<img width="803" alt="image" src="https://github.com/user-attachments/assets/417e3c08-bd91-4a57-95c9-6aa07d1c8431">
<img width="792" alt="image" src="https://github.com/user-attachments/assets/bd531064-0423-481f-9f97-32a39e3a0038">


<br/>

### 📝 논의사항

1. 사진 갯수 제한은 어차피 프론트 화면에서 4개까지 선택할 수 있어서 안했는데 해야하나요?
2. 동영상 크기 제한은 백에서 할 수 있습니다만 얼마로 제한해야할지 안정해져서 안했습니다
3. 400 에러 뜰 때 에러 response body에 custom error 메세지가 안뜨네요 왜 그런지 모르겠어요
