### PR TITLE
[feature] 지난 여행 조각 받아오기 구현(전체/사진/영상/메모) + token 적용

### DIFF
--- a/src/main/java/umc/TripPiece/converter/TravelConverter.java
+++ b/src/main/java/umc/TripPiece/converter/TravelConverter.java
@@ -14,9 +14,10 @@ import java.util.stream.Collectors;
 
 public class TravelConverter {
 
-    public static TripPiece toTripPieceMemo(TravelRequestDto.MemoDto request) {
+    public static TripPiece toTripPieceMemo(TravelRequestDto.MemoDto request, User user) {
         return TripPiece.builder()
                 .description(request.getDescription())
+                .user(user)
                 .build();
     }
 

--- a/src/main/java/umc/TripPiece/converter/TripPieceConverter.java
+++ b/src/main/java/umc/TripPiece/converter/TripPieceConverter.java
@@ -1,10 +1,7 @@
 package umc.TripPiece.converter;
 
-import umc.TripPiece.domain.Emoji;
-import umc.TripPiece.domain.Picture;
-import umc.TripPiece.domain.TripPiece;
-import umc.TripPiece.domain.Video;
-import umc.TripPiece.web.dto.request.TravelRequestDto;
+import umc.TripPiece.domain.*;
+import umc.TripPiece.web.dto.response.TripPieceResponseDto;
 
 public class TripPieceConverter {
 
@@ -27,5 +24,13 @@ public class TripPieceConverter {
                 .videoUrl(videoUrl)
                 .tripPiece(tripPiece)
                 .build();
+    }
+
+    public static TripPieceResponseDto.TripPieceListDto toTripPieceList(TripPiece tripPiece) {
+        return TripPieceResponseDto.TripPieceListDto.builder()
+                .createdAt(tripPiece.getCreatedAt())
+                .category(tripPiece.getCategory())
+                .build();
+
     }
 }

--- a/src/main/java/umc/TripPiece/domain/TripPiece.java
+++ b/src/main/java/umc/TripPiece/domain/TripPiece.java
@@ -36,6 +36,10 @@ public class TripPiece extends BaseEntity {
     @JoinColumn(name = "travel_id")
     private Travel travel;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     @OneToMany(mappedBy = "tripPiece", cascade = CascadeType.ALL)
     private List<Picture> pictures = new ArrayList<>();
 

--- a/src/main/java/umc/TripPiece/domain/User.java
+++ b/src/main/java/umc/TripPiece/domain/User.java
@@ -6,6 +6,9 @@ import umc.TripPiece.domain.common.BaseEntity;
 import umc.TripPiece.domain.enums.Gender;
 import umc.TripPiece.domain.enums.UserMethod;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -55,4 +58,7 @@ public class User extends BaseEntity {
     @Setter
     @Column(name = "refresh_token")
     private String refreshToken;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<TripPiece> tripPieces = new ArrayList<>();
 }

--- a/src/main/java/umc/TripPiece/repository/TravelRepository.java
+++ b/src/main/java/umc/TripPiece/repository/TravelRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface TravelRepository extends JpaRepository<Travel, Long> {
     List<Travel> findByCityId(Long cityId);
     List<Travel> findByCity_CountryId(Long countryId);
-    Travel findByStatus(TravelStatus travelStatus);
+    Travel findByStatusAndUserId(TravelStatus travelStatus, Long userId);
 
     List<Travel> findByUserId(Long userId);
 

--- a/src/main/java/umc/TripPiece/repository/TripPieceRepository.java
+++ b/src/main/java/umc/TripPiece/repository/TripPieceRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface TripPieceRepository extends JpaRepository<TripPiece, Long> {
     List<TripPiece> findByTravelId(Long travelId);
+    List<TripPiece> findByUserIdOrderByCreatedAtDesc(Long userId);
+    List<TripPiece> findByUserIdOrderByCreatedAtAsc(Long userId);
 }

--- a/src/main/java/umc/TripPiece/repository/TripPieceRepository.java
+++ b/src/main/java/umc/TripPiece/repository/TripPieceRepository.java
@@ -2,6 +2,7 @@ package umc.TripPiece.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.TripPiece.domain.TripPiece;
+import umc.TripPiece.domain.enums.Category;
 
 import java.util.List;
 
@@ -9,4 +10,7 @@ public interface TripPieceRepository extends JpaRepository<TripPiece, Long> {
     List<TripPiece> findByTravelId(Long travelId);
     List<TripPiece> findByUserIdOrderByCreatedAtDesc(Long userId);
     List<TripPiece> findByUserIdOrderByCreatedAtAsc(Long userId);
+    List<TripPiece> findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(Long userId, Category category1, Category category2);
+    List<TripPiece> findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(Long userId, Category category1, Category category2);
+
 }

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -55,9 +55,10 @@ public class TravelService {
 
 
     @Transactional
-    public TripPiece createMemo(Long travelId, TravelRequestDto.MemoDto request) {
+    public TripPiece createMemo(Long travelId, Long userId, TravelRequestDto.MemoDto request) {
+        User user = userRepository.findById(userId).orElseThrow();
 
-        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
         newTripPiece.setCategory(Category.MEMO);
 
@@ -68,9 +69,10 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createEmoji(Long travelId, List<String> emojis, TravelRequestDto.MemoDto request) {
+    public TripPiece createEmoji(Long travelId, Long userId, List<String> emojis, TravelRequestDto.MemoDto request) {
+        User user = userRepository.findById(userId).orElseThrow();
 
-        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
         newTripPiece.setCategory(Category.EMOJI);
 
@@ -86,9 +88,10 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createPicture(Long travelId, List<MultipartFile> pictures, TravelRequestDto.MemoDto request) {
+    public TripPiece createPicture(Long travelId, Long userId, List<MultipartFile> pictures, TravelRequestDto.MemoDto request) {
+        User user = userRepository.findById(userId).orElseThrow();
 
-        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
         newTripPiece.setCategory(Category.PICTURE);
 
@@ -118,9 +121,10 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createSelfie(Long travelId, MultipartFile picture, TravelRequestDto.MemoDto request) {
+    public TripPiece createSelfie(Long travelId, Long userId, MultipartFile picture, TravelRequestDto.MemoDto request) {
+        User user = userRepository.findById(userId).orElseThrow();
 
-        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
         newTripPiece.setCategory(Category.SELFIE);
 
@@ -142,9 +146,10 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createVideo(Long travelId, MultipartFile video, TravelRequestDto.MemoDto request) {
+    public TripPiece createVideo(Long travelId, Long userId, MultipartFile video, TravelRequestDto.MemoDto request) {
+        User user = userRepository.findById(userId).orElseThrow();
 
-        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
         newTripPiece.setCategory(Category.VIDEO);
 
@@ -166,9 +171,10 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createWhere(Long travelId, MultipartFile video, TravelRequestDto.MemoDto request) {
+    public TripPiece createWhere(Long travelId, Long userId, MultipartFile video, TravelRequestDto.MemoDto request) {
+        User user = userRepository.findById(userId).orElseThrow();
 
-        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request);
+        TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
         newTripPiece.setCategory(Category.WHERE);
 

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -34,9 +34,9 @@ public class TravelService {
     private final PictureRepository pictureRepository;
     private final VideoRepository videoRepository;
     private final UuidRepository uuidRepository;
+    private final UserRepository userRepository;
     private final AmazonS3Manager s3Manager;
     private final JWTUtil jwtUtil;
-    private final UserRepository userRepository;
 
     public List<Travel> searchByKeyword(String keyword) {
         List<City> cities = cityRepository.findByNameContainingIgnoreCase(keyword);
@@ -55,8 +55,9 @@ public class TravelService {
 
 
     @Transactional
-    public TripPiece createMemo(Long travelId, Long userId, TravelRequestDto.MemoDto request) {
-        User user = userRepository.findById(userId).orElseThrow();
+    public TripPiece createMemo(Long travelId, TravelRequestDto.MemoDto request, String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("user not found"));
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
@@ -69,8 +70,9 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createEmoji(Long travelId, Long userId, List<String> emojis, TravelRequestDto.MemoDto request) {
-        User user = userRepository.findById(userId).orElseThrow();
+    public TripPiece createEmoji(Long travelId, List<String> emojis, TravelRequestDto.MemoDto request, String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("user not found"));
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
@@ -88,8 +90,9 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createPicture(Long travelId, Long userId, List<MultipartFile> pictures, TravelRequestDto.MemoDto request) {
-        User user = userRepository.findById(userId).orElseThrow();
+    public TripPiece createPicture(Long travelId, List<MultipartFile> pictures, TravelRequestDto.MemoDto request, String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("user not found"));
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
@@ -121,8 +124,9 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createSelfie(Long travelId, Long userId, MultipartFile picture, TravelRequestDto.MemoDto request) {
-        User user = userRepository.findById(userId).orElseThrow();
+    public TripPiece createSelfie(Long travelId, MultipartFile picture, TravelRequestDto.MemoDto request, String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("user not found"));
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
@@ -146,8 +150,9 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createVideo(Long travelId, Long userId, MultipartFile video, TravelRequestDto.MemoDto request) {
-        User user = userRepository.findById(userId).orElseThrow();
+    public TripPiece createVideo(Long travelId, MultipartFile video, TravelRequestDto.MemoDto request, String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("user not found"));;
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
@@ -171,8 +176,9 @@ public class TravelService {
     }
 
     @Transactional
-    public TripPiece createWhere(Long travelId, Long userId, MultipartFile video, TravelRequestDto.MemoDto request) {
-        User user = userRepository.findById(userId).orElseThrow();
+    public TripPiece createWhere(Long travelId, MultipartFile video, TravelRequestDto.MemoDto request, String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("user not found"));
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travelRepository.findById(travelId).get());
@@ -252,8 +258,9 @@ public class TravelService {
     }
 
     @Transactional
-    public TravelResponseDto.getOngoingTravelResultDto getOngoingTravel() {
-        Travel travel = travelRepository.findByStatus(TravelStatus.ONGOING);
+    public TravelResponseDto.getOngoingTravelResultDto getOngoingTravel(String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        Travel travel = travelRepository.findByStatusAndUserId(TravelStatus.ONGOING, userId);
         return TravelConverter.toOngoingTravelResultDto(travel);
     }
 

--- a/src/main/java/umc/TripPiece/service/TripPieceService.java
+++ b/src/main/java/umc/TripPiece/service/TripPieceService.java
@@ -124,4 +124,196 @@ public class TripPieceService {
 
         return tripPieceList;
     }
+
+    @Transactional
+    public List<TripPieceResponseDto.TripPieceListDto> getMemoListLatest(Long userId) {
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
+        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.MEMO, Category.EMOJI);
+
+        for (TripPiece tripPiece : tripPieces) {
+            Travel travel = tripPiece.getTravel();
+            City city = travel.getCity();
+            Country country = city.getCountry();
+            Category category = tripPiece.getCategory();
+
+            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
+
+            tripPieceListDto.setCategory(Category.MEMO);
+
+            if (category == Category.MEMO)
+            {
+                tripPieceListDto.setMemo(tripPiece.getDescription());
+            }
+            else if (category == Category.EMOJI)
+            {
+                List<Emoji> emojis = tripPiece.getEmojis();
+
+                tripPieceListDto.setMemo(emojis.get(0).getEmoji() + emojis.get(1).getEmoji() + emojis.get(2).getEmoji() + emojis.get(3).getEmoji());
+            }
+
+            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
+            tripPieceListDto.setCountryName(country.getName());
+            tripPieceListDto.setCityName(city.getName());
+
+            tripPieceList.add(tripPieceListDto);
+        }
+
+        return tripPieceList;
+    }
+
+    @Transactional
+    public List<TripPieceResponseDto.TripPieceListDto> getMemoListEarliest(Long userId) {
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
+        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.MEMO, Category.EMOJI);
+
+        for (TripPiece tripPiece : tripPieces) {
+            Travel travel = tripPiece.getTravel();
+            City city = travel.getCity();
+            Country country = city.getCountry();
+            Category category = tripPiece.getCategory();
+
+            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
+
+            tripPieceListDto.setCategory(Category.MEMO);
+
+            if (category == Category.MEMO)
+            {
+                tripPieceListDto.setMemo(tripPiece.getDescription());
+            }
+            else if (category == Category.EMOJI)
+            {
+                List<Emoji> emojis = tripPiece.getEmojis();
+
+                tripPieceListDto.setMemo(emojis.get(0).getEmoji() + emojis.get(1).getEmoji() + emojis.get(2).getEmoji() + emojis.get(3).getEmoji());
+            }
+
+            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
+            tripPieceListDto.setCountryName(country.getName());
+            tripPieceListDto.setCityName(city.getName());
+
+            tripPieceList.add(tripPieceListDto);
+        }
+
+        return tripPieceList;
+    }
+
+    @Transactional
+    public List<TripPieceResponseDto.TripPieceListDto> getPictureListLatest(Long userId) {
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
+        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.PICTURE, Category.SELFIE);
+
+        for (TripPiece tripPiece : tripPieces) {
+            Travel travel = tripPiece.getTravel();
+            City city = travel.getCity();
+            Country country = city.getCountry();
+
+            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
+
+            // 여러개 사진이 있다면, 썸네일 랜덤
+            List<Picture> pictures = tripPiece.getPictures();
+            Random random = new Random();
+            int randomIndex = random.nextInt(pictures.size());
+
+            tripPieceListDto.setCategory(Category.PICTURE);
+            tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
+
+            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
+            tripPieceListDto.setCountryName(country.getName());
+            tripPieceListDto.setCityName(city.getName());
+
+            tripPieceList.add(tripPieceListDto);
+        }
+
+        return tripPieceList;
+    }
+
+
+    @Transactional
+    public List<TripPieceResponseDto.TripPieceListDto> getPictureListEarliest(Long userId) {
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
+        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.PICTURE, Category.SELFIE);
+
+        for (TripPiece tripPiece : tripPieces) {
+            Travel travel = tripPiece.getTravel();
+            City city = travel.getCity();
+            Country country = city.getCountry();
+
+            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
+
+            // 여러개 사진이 있다면, 썸네일 랜덤
+            List<Picture> pictures = tripPiece.getPictures();
+            Random random = new Random();
+            int randomIndex = random.nextInt(pictures.size());
+
+            tripPieceListDto.setCategory(Category.PICTURE);
+            tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
+
+            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
+            tripPieceListDto.setCountryName(country.getName());
+            tripPieceListDto.setCityName(city.getName());
+
+            tripPieceList.add(tripPieceListDto);
+        }
+
+        return tripPieceList;
+    }
+
+    @Transactional
+    public List<TripPieceResponseDto.TripPieceListDto> getVideoListLatest(Long userId) {
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
+        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.VIDEO, Category.WHERE);
+
+        for (TripPiece tripPiece : tripPieces) {
+            Travel travel = tripPiece.getTravel();
+            City city = travel.getCity();
+            Country country = city.getCountry();
+
+            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
+
+            List<Video> videos = tripPiece.getVideos();
+            Video video = videos.get(0);
+
+            tripPieceListDto.setCategory(Category.VIDEO);
+            tripPieceListDto.setMediaUrl(video.getVideoUrl());
+
+            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
+            tripPieceListDto.setCountryName(country.getName());
+            tripPieceListDto.setCityName(city.getName());
+
+            tripPieceList.add(tripPieceListDto);
+        }
+
+        return tripPieceList;
+    }
+
+    @Transactional
+    public List<TripPieceResponseDto.TripPieceListDto> getVideoListEarliest(Long userId) {
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
+        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.VIDEO, Category.WHERE);
+
+        for (TripPiece tripPiece : tripPieces) {
+            Travel travel = tripPiece.getTravel();
+            City city = travel.getCity();
+            Country country = city.getCountry();
+
+            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
+
+            List<Video> videos = tripPiece.getVideos();
+            Video video = videos.get(0);
+
+            tripPieceListDto.setCategory(Category.VIDEO);
+            tripPieceListDto.setMediaUrl(video.getVideoUrl());
+
+            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
+            tripPieceListDto.setCountryName(country.getName());
+            tripPieceListDto.setCityName(city.getName());
+
+            tripPieceList.add(tripPieceListDto);
+        }
+
+        return tripPieceList;
+    }
+
+
+
 }

--- a/src/main/java/umc/TripPiece/service/TripPieceService.java
+++ b/src/main/java/umc/TripPiece/service/TripPieceService.java
@@ -1,0 +1,127 @@
+package umc.TripPiece.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.TripPiece.domain.*;
+import umc.TripPiece.domain.enums.Category;
+import umc.TripPiece.repository.TripPieceRepository;
+import umc.TripPiece.web.dto.response.TripPieceResponseDto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TripPieceService {
+
+    private final TripPieceRepository tripPieceRepository;
+
+    @Transactional
+    public List<TripPieceResponseDto.TripPieceListDto> getTripPieceListLatest(Long userId) {
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
+        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        for (TripPiece tripPiece : tripPieces) {
+            Travel travel = tripPiece.getTravel();
+            City city = travel.getCity();
+            Country country = city.getCountry();
+            Category category = tripPiece.getCategory();
+
+            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
+
+            if (category == Category.MEMO)
+            {
+                tripPieceListDto.setCategory(Category.MEMO);
+                tripPieceListDto.setMemo(tripPiece.getDescription());
+            }
+            else if (category == Category.EMOJI)
+            {
+                List<Emoji> emojis = tripPiece.getEmojis();
+
+                tripPieceListDto.setCategory(Category.MEMO);
+                tripPieceListDto.setMemo(emojis.get(0).getEmoji() + emojis.get(1).getEmoji() + emojis.get(2).getEmoji() + emojis.get(3).getEmoji());
+            }
+            else if (category == Category.PICTURE || category == Category.SELFIE)
+            {
+                // 여러개 사진이 있다면, 썸네일 랜덤
+                List<Picture> pictures = tripPiece.getPictures();
+                Random random = new Random();
+                int randomIndex = random.nextInt(pictures.size());
+
+                tripPieceListDto.setCategory(Category.PICTURE);
+                tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
+            }
+            else if (category == Category.VIDEO || category == Category.WHERE)
+            {
+                List<Video> videos = tripPiece.getVideos();
+                Video video = videos.get(0);
+
+                tripPieceListDto.setCategory(Category.VIDEO);
+                tripPieceListDto.setMediaUrl(video.getVideoUrl());
+            }
+
+            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
+            tripPieceListDto.setCountryName(country.getName());
+            tripPieceListDto.setCityName(city.getName());
+
+            tripPieceList.add(tripPieceListDto);
+        }
+
+        return tripPieceList;
+    }
+
+    @Transactional
+    public List<TripPieceResponseDto.TripPieceListDto> getTripPieceListEarliest(Long userId) {
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
+        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdOrderByCreatedAtAsc(userId);
+        for (TripPiece tripPiece : tripPieces) {
+            Travel travel = tripPiece.getTravel();
+            City city = travel.getCity();
+            Country country = city.getCountry();
+            Category category = tripPiece.getCategory();
+
+            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
+
+            if (category == Category.MEMO)
+            {
+                tripPieceListDto.setCategory(Category.MEMO);
+                tripPieceListDto.setMemo(tripPiece.getDescription());
+            }
+            else if (category == Category.EMOJI)
+            {
+                List<Emoji> emojis = tripPiece.getEmojis();
+
+                tripPieceListDto.setCategory(Category.MEMO);
+                tripPieceListDto.setMemo(emojis.get(0).getEmoji() + emojis.get(1).getEmoji() + emojis.get(2).getEmoji() + emojis.get(3).getEmoji());
+            }
+            else if (category == Category.PICTURE || category == Category.SELFIE)
+            {
+                // 여러개 사진이 있다면, 썸네일 랜덤
+                List<Picture> pictures = tripPiece.getPictures();
+                Random random = new Random();
+                int randomIndex = random.nextInt(pictures.size());
+
+                tripPieceListDto.setCategory(Category.PICTURE);
+                tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
+            }
+            else if (category == Category.VIDEO || category == Category.WHERE)
+            {
+                List<Video> videos = tripPiece.getVideos();
+                Video video = videos.get(0);
+
+                tripPieceListDto.setCategory(Category.VIDEO);
+                tripPieceListDto.setMediaUrl(video.getVideoUrl());
+            }
+
+            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
+            tripPieceListDto.setCountryName(country.getName());
+            tripPieceListDto.setCityName(city.getName());
+
+            tripPieceList.add(tripPieceListDto);
+        }
+
+        return tripPieceList;
+    }
+}

--- a/src/main/java/umc/TripPiece/service/TripPieceService.java
+++ b/src/main/java/umc/TripPiece/service/TripPieceService.java
@@ -5,7 +5,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.TripPiece.domain.*;
 import umc.TripPiece.domain.enums.Category;
+import umc.TripPiece.domain.jwt.JWTUtil;
 import umc.TripPiece.repository.TripPieceRepository;
+import umc.TripPiece.repository.UserRepository;
 import umc.TripPiece.web.dto.response.TripPieceResponseDto;
 
 import java.util.ArrayList;
@@ -18,9 +20,12 @@ import java.util.Random;
 public class TripPieceService {
 
     private final TripPieceRepository tripPieceRepository;
+    private final JWTUtil jwtUtil;
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getTripPieceListLatest(Long userId) {
+    public List<TripPieceResponseDto.TripPieceListDto> getTripPieceListLatest(String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
         List<TripPiece> tripPieces = tripPieceRepository.findByUserIdOrderByCreatedAtDesc(userId);
         for (TripPiece tripPiece : tripPieces) {
@@ -73,7 +78,9 @@ public class TripPieceService {
     }
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getTripPieceListEarliest(Long userId) {
+    public List<TripPieceResponseDto.TripPieceListDto> getTripPieceListEarliest(String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
         List<TripPiece> tripPieces = tripPieceRepository.findByUserIdOrderByCreatedAtAsc(userId);
         for (TripPiece tripPiece : tripPieces) {
@@ -126,7 +133,9 @@ public class TripPieceService {
     }
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getMemoListLatest(Long userId) {
+    public List<TripPieceResponseDto.TripPieceListDto> getMemoListLatest(String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
         List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.MEMO, Category.EMOJI);
 
@@ -162,7 +171,9 @@ public class TripPieceService {
     }
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getMemoListEarliest(Long userId) {
+    public List<TripPieceResponseDto.TripPieceListDto> getMemoListEarliest(String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
         List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.MEMO, Category.EMOJI);
 
@@ -198,7 +209,9 @@ public class TripPieceService {
     }
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getPictureListLatest(Long userId) {
+    public List<TripPieceResponseDto.TripPieceListDto> getPictureListLatest(String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
         List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.PICTURE, Category.SELFIE);
 
@@ -229,7 +242,9 @@ public class TripPieceService {
 
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getPictureListEarliest(Long userId) {
+    public List<TripPieceResponseDto.TripPieceListDto> getPictureListEarliest(String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
         List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.PICTURE, Category.SELFIE);
 
@@ -259,7 +274,9 @@ public class TripPieceService {
     }
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getVideoListLatest(Long userId) {
+    public List<TripPieceResponseDto.TripPieceListDto> getVideoListLatest(String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
         List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.VIDEO, Category.WHERE);
 
@@ -287,7 +304,9 @@ public class TripPieceService {
     }
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getVideoListEarliest(Long userId) {
+    public List<TripPieceResponseDto.TripPieceListDto> getVideoListEarliest(String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
         List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.VIDEO, Category.WHERE);
 

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -54,43 +54,43 @@ public class TravelController {
 
     @PostMapping("/mytravels/{travelId}/memo")
     @Operation(summary = "메모 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceMemo(@RequestBody @TextLength100 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId){
-        TripPiece tripPiece = travelService.createMemo(travelId, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceMemo(@RequestBody @TextLength100 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId){
+        TripPiece tripPiece = travelService.createMemo(travelId, userId, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping("/mytravels/{travelId}/emoji")
     @Operation(summary = "이모지 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceEmoji(@RequestBody @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam(name = "emojis") @CheckEmoji @CheckEmojiNum List<String> emojis){
-        TripPiece tripPiece = travelService.createEmoji(travelId, emojis, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceEmoji(@RequestBody @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestParam(name = "emojis") @CheckEmoji @CheckEmojiNum List<String> emojis){
+        TripPiece tripPiece = travelService.createEmoji(travelId, userId, emojis, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/picture", consumes = "multipart/form-data")
     @Operation(summary = "사진 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPiecePicture(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("photos") List<MultipartFile> photos){
-        TripPiece tripPiece = travelService.createPicture(travelId, photos, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPiecePicture(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestPart("photos") List<MultipartFile> photos){
+        TripPiece tripPiece = travelService.createPicture(travelId, userId, photos, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/selfie", consumes = "multipart/form-data")
     @Operation(summary = "셀카 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceSelfie(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("photo") MultipartFile photo){
-        TripPiece tripPiece = travelService.createSelfie(travelId, photo, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceSelfie(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestPart("photo") MultipartFile photo){
+        TripPiece tripPiece = travelService.createSelfie(travelId, userId, photo, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/video", consumes = "multipart/form-data")
     @Operation(summary = "비디오 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceVideo(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("video") MultipartFile video){
-        TripPiece tripPiece = travelService.createVideo(travelId, video, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceVideo(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestPart("video") MultipartFile video){
+        TripPiece tripPiece = travelService.createVideo(travelId, userId, video, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/where", consumes = "multipart/form-data")
     @Operation(summary = "'지금 어디에 있나요?' 카테고리 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceWhere(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestPart("video") MultipartFile video){
-        TripPiece tripPiece = travelService.createWhere(travelId, video, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceWhere(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestPart("video") MultipartFile video){
+        TripPiece tripPiece = travelService.createWhere(travelId, userId, video, request);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -54,43 +54,49 @@ public class TravelController {
 
     @PostMapping("/mytravels/{travelId}/memo")
     @Operation(summary = "메모 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceMemo(@RequestBody @TextLength100 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId){
-        TripPiece tripPiece = travelService.createMemo(travelId, userId, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceMemo(@RequestBody @TextLength100 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        TripPiece tripPiece = travelService.createMemo(travelId, request, tokenWithoutBearer);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping("/mytravels/{travelId}/emoji")
     @Operation(summary = "이모지 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceEmoji(@RequestBody @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestParam(name = "emojis") @CheckEmoji @CheckEmojiNum List<String> emojis){
-        TripPiece tripPiece = travelService.createEmoji(travelId, userId, emojis, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceEmoji(@RequestBody @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestHeader("Authorization") String token, @RequestParam(name = "emojis") @CheckEmoji @CheckEmojiNum List<String> emojis){
+        String tokenWithoutBearer = token.substring(7);
+        TripPiece tripPiece = travelService.createEmoji(travelId, emojis, request, tokenWithoutBearer);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/picture", consumes = "multipart/form-data")
     @Operation(summary = "사진 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPiecePicture(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestPart("photos") List<MultipartFile> photos){
-        TripPiece tripPiece = travelService.createPicture(travelId, userId, photos, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPiecePicture(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestHeader("Authorization") String token, @RequestPart("photos") List<MultipartFile> photos){
+        String tokenWithoutBearer = token.substring(7);
+        TripPiece tripPiece = travelService.createPicture(travelId, photos, request, tokenWithoutBearer);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/selfie", consumes = "multipart/form-data")
     @Operation(summary = "셀카 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceSelfie(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestPart("photo") MultipartFile photo){
-        TripPiece tripPiece = travelService.createSelfie(travelId, userId, photo, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceSelfie(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestHeader("Authorization") String token, @RequestPart("photo") MultipartFile photo){
+        String tokenWithoutBearer = token.substring(7);
+        TripPiece tripPiece = travelService.createSelfie(travelId, photo, request, tokenWithoutBearer);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/video", consumes = "multipart/form-data")
     @Operation(summary = "비디오 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceVideo(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestPart("video") MultipartFile video){
-        TripPiece tripPiece = travelService.createVideo(travelId, userId, video, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceVideo(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestHeader("Authorization") String token, @RequestPart("video") MultipartFile video){
+        String tokenWithoutBearer = token.substring(7);
+        TripPiece tripPiece = travelService.createVideo(travelId, video, request, tokenWithoutBearer);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
     @PostMapping(value = "/mytravels/{travelId}/where", consumes = "multipart/form-data")
     @Operation(summary = "'지금 어디에 있나요?' 카테고리 기록 API", description = "특정 여행기에서의 여행조각 추가")
-    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceWhere(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestParam("userId") Long userId, @RequestPart("video") MultipartFile video){
-        TripPiece tripPiece = travelService.createWhere(travelId, userId, video, request);
+    public ApiResponse<TravelResponseDto.CreateTripPieceResultDto> createTripPieceWhere(@RequestPart("memo") @TextLength30 TravelRequestDto.MemoDto request, @PathVariable("travelId") Long travelId, @RequestHeader("Authorization") String token, @RequestPart("video") MultipartFile video){
+        String tokenWithoutBearer = token.substring(7);
+        TripPiece tripPiece = travelService.createWhere(travelId, video, request, tokenWithoutBearer);
         return ApiResponse.onSuccess(TravelConverter.toCreateTripPieceResultDto(tripPiece));
     }
 
@@ -111,8 +117,9 @@ public class TravelController {
 
     @GetMapping("/mytravels")
     @Operation(summary = "현재 진행중인 여행기 반환 API", description = "현재 진행중인 여행기 반환")
-    public ApiResponse<TravelResponseDto.getOngoingTravelResultDto> getOngoingTravel(){
-        TravelResponseDto.getOngoingTravelResultDto travel = travelService.getOngoingTravel();
+    public ApiResponse<TravelResponseDto.getOngoingTravelResultDto> getOngoingTravel(@RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        TravelResponseDto.getOngoingTravelResultDto travel = travelService.getOngoingTravel(tokenWithoutBearer);
         return ApiResponse.onSuccess(travel);
     }
 

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -18,16 +18,58 @@ public class TripPieceController {
     private final TripPieceService tripPieceService;
 
     @GetMapping("/mytrippieces/all/latest")
-    @Operation(summary = "지난 여행 조각(전체, 최신순) API", description = "유저의 여행조각을 최신순으로 반환")
+    @Operation(summary = "지난 여행 조각(전체, 최신순) API", description = "유저의 여행조각(전체)을 최신순으로 반환")
     public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListLatest(@RequestParam("userId") Long userId){
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListLatest(userId);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
     @GetMapping("/mytrippieces/all/earliest")
-    @Operation(summary = "지난 여행 조각(전체, 오래된순) API", description = "유저의 여행조각을 오래된순으로 반환")
+    @Operation(summary = "지난 여행 조각(전체, 오래된순) API", description = "유저의 여행조각(전체)을 오래된순으로 반환")
     public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListEarliest(@RequestParam("userId") Long userId){
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListEarliest(userId);
+        return ApiResponse.onSuccess(tripPieceList);
+    }
+
+    @GetMapping("/mytrippieces/memo/latest")
+    @Operation(summary = "지난 여행 조각(메모, 최신순) API", description = "유저의 여행조각(메모, 이모지)을 최신순으로 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListLatest(@RequestParam("userId") Long userId){
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoListLatest(userId);
+        return ApiResponse.onSuccess(tripPieceList);
+    }
+
+    @GetMapping("/mytrippieces/memo/earliest")
+    @Operation(summary = "지난 여행 조각(메모, 오래된순) API", description = "유저의 여행조각(메모, 이모지)을 오래된순으로 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListEarliest(@RequestParam("userId") Long userId){
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoListEarliest(userId);
+        return ApiResponse.onSuccess(tripPieceList);
+    }
+
+    @GetMapping("/mytrippieces/picture/latest")
+    @Operation(summary = "지난 여행 조각(사진, 최신순) API", description = "유저의 여행조각(사진, 셀카)을 최신순으로 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListLatest(@RequestParam("userId") Long userId){
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureListLatest(userId);
+        return ApiResponse.onSuccess(tripPieceList);
+    }
+
+    @GetMapping("/mytrippieces/picture/earliest")
+    @Operation(summary = "지난 여행 조각(사진, 오래된순) API", description = "유저의 여행조각(사진, 셀카)을 오래된순으로 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListEarliest(@RequestParam("userId") Long userId){
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureListEarliest(userId);
+        return ApiResponse.onSuccess(tripPieceList);
+    }
+
+    @GetMapping("/mytrippieces/video/latest")
+    @Operation(summary = "지난 여행 조각(동영상, 최신순) API", description = "유저의 여행조각(영상, '지금 어디에 있나요?')을 최신순으로 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListLatest(@RequestParam("userId") Long userId){
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoListLatest(userId);
+        return ApiResponse.onSuccess(tripPieceList);
+    }
+
+    @GetMapping("/mytrippieces/video/earliest")
+    @Operation(summary = "지난 여행 조각(동영상, 오래된순) API", description = "유저의 여행조각(영상, '지금 어디에 있나요?')을 오래된순으로 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListEarliest(@RequestParam("userId") Long userId){
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoListEarliest(userId);
         return ApiResponse.onSuccess(tripPieceList);
     }
 }

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -3,6 +3,7 @@ package umc.TripPiece.web.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.TripPiece.payload.ApiResponse;
@@ -19,57 +20,65 @@ public class TripPieceController {
 
     @GetMapping("/mytrippieces/all/latest")
     @Operation(summary = "지난 여행 조각(전체, 최신순) API", description = "유저의 여행조각(전체)을 최신순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListLatest(@RequestParam("userId") Long userId){
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListLatest(userId);
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListLatest(@RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListLatest(tokenWithoutBearer);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
     @GetMapping("/mytrippieces/all/earliest")
     @Operation(summary = "지난 여행 조각(전체, 오래된순) API", description = "유저의 여행조각(전체)을 오래된순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListEarliest(@RequestParam("userId") Long userId){
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListEarliest(userId);
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListEarliest(@RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListEarliest(tokenWithoutBearer);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
     @GetMapping("/mytrippieces/memo/latest")
     @Operation(summary = "지난 여행 조각(메모, 최신순) API", description = "유저의 여행조각(메모, 이모지)을 최신순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListLatest(@RequestParam("userId") Long userId){
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoListLatest(userId);
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListLatest(@RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoListLatest(tokenWithoutBearer);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
     @GetMapping("/mytrippieces/memo/earliest")
     @Operation(summary = "지난 여행 조각(메모, 오래된순) API", description = "유저의 여행조각(메모, 이모지)을 오래된순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListEarliest(@RequestParam("userId") Long userId){
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoListEarliest(userId);
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListEarliest(@RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoListEarliest(tokenWithoutBearer);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
     @GetMapping("/mytrippieces/picture/latest")
     @Operation(summary = "지난 여행 조각(사진, 최신순) API", description = "유저의 여행조각(사진, 셀카)을 최신순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListLatest(@RequestParam("userId") Long userId){
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureListLatest(userId);
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListLatest(@RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureListLatest(tokenWithoutBearer);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
     @GetMapping("/mytrippieces/picture/earliest")
     @Operation(summary = "지난 여행 조각(사진, 오래된순) API", description = "유저의 여행조각(사진, 셀카)을 오래된순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListEarliest(@RequestParam("userId") Long userId){
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureListEarliest(userId);
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListEarliest(@RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureListEarliest(tokenWithoutBearer);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
     @GetMapping("/mytrippieces/video/latest")
     @Operation(summary = "지난 여행 조각(동영상, 최신순) API", description = "유저의 여행조각(영상, '지금 어디에 있나요?')을 최신순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListLatest(@RequestParam("userId") Long userId){
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoListLatest(userId);
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListLatest(@RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoListLatest(tokenWithoutBearer);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
     @GetMapping("/mytrippieces/video/earliest")
     @Operation(summary = "지난 여행 조각(동영상, 오래된순) API", description = "유저의 여행조각(영상, '지금 어디에 있나요?')을 오래된순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListEarliest(@RequestParam("userId") Long userId){
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoListEarliest(userId);
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListEarliest(@RequestHeader("Authorization") String token){
+        String tokenWithoutBearer = token.substring(7);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoListEarliest(tokenWithoutBearer);
         return ApiResponse.onSuccess(tripPieceList);
     }
 }

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -1,0 +1,33 @@
+package umc.TripPiece.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.TripPiece.payload.ApiResponse;
+import umc.TripPiece.service.TripPieceService;
+import umc.TripPiece.web.dto.response.TripPieceResponseDto;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TripPieceController {
+
+    private final TripPieceService tripPieceService;
+
+    @GetMapping("/mytrippieces/all/latest")
+    @Operation(summary = "지난 여행 조각(전체, 최신순) API", description = "유저의 여행조각을 최신순으로 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListLatest(@RequestParam("userId") Long userId){
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListLatest(userId);
+        return ApiResponse.onSuccess(tripPieceList);
+    }
+
+    @GetMapping("/mytrippieces/all/earliest")
+    @Operation(summary = "지난 여행 조각(전체, 오래된순) API", description = "유저의 여행조각을 오래된순으로 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListEarliest(@RequestParam("userId") Long userId){
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListEarliest(userId);
+        return ApiResponse.onSuccess(tripPieceList);
+    }
+}

--- a/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
@@ -93,5 +93,4 @@ public class TravelResponseDto {
         Integer videoNum;
     }
 
-
 }

--- a/src/main/java/umc/TripPiece/web/dto/response/TripPieceResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TripPieceResponseDto.java
@@ -1,0 +1,23 @@
+package umc.TripPiece.web.dto.response;
+
+import lombok.*;
+import umc.TripPiece.domain.enums.Category;
+
+import java.time.LocalDateTime;
+
+public class TripPieceResponseDto {
+
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TripPieceListDto {
+        Category category;
+        LocalDateTime createdAt;
+        String countryName;
+        String cityName;
+        String memo;
+        String mediaUrl;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 연관 이슈

close #32 

<br/>

## 개요

userId를 받아와 해당 유저의 지난 여행 조각을 받아옵니다.
전체/사진/영상/메모 카테고리별로 API 구현 완료했습니다.
사진은 4개 중 하나 랜덤으로 출력됩니다.
아래는 전체 불러오는 Swagger 예시
1) 전체, 최신순
<img width="798" alt="image" src="https://github.com/user-attachments/assets/561018df-3fe0-460d-a0d1-bc87dbe9fbdb">

2) 전체, 오래된순
<img width="799" alt="image" src="https://github.com/user-attachments/assets/6ae80de9-afef-4b6f-aa09-dc1d92fe5244">

여행 조각 생성, 현재 진행 중 여행 불러오기, 지난 여행 조각 받아오기 시에 token으로 받아올 수 있게 변경

<br/>

## ✅ 작업 내용

- [ ] TripPiece 테이블에 user 맵핑
- [ ] 모든 여행 조각 가져오기(최신순, 오래된순)
- [ ] 카테고리별 여행 조각 가져오기(최신순, 오래된순)

<br/>

### 📝 논의사항

여행조각이 많아지면 한 번에 받아오는데 시간이 걸리므로 페이징 구현 필요함(프론트와 논의 필요)

