### PR TITLE
[feature] 단일 여행 조각 조회 구현

### DIFF
--- a/src/main/java/umc/TripPiece/converter/TripPieceConverter.java
+++ b/src/main/java/umc/TripPiece/converter/TripPieceConverter.java
@@ -3,6 +3,8 @@ package umc.TripPiece.converter;
 import umc.TripPiece.domain.*;
 import umc.TripPiece.web.dto.response.TripPieceResponseDto;
 
+import java.util.List;
+
 public class TripPieceConverter {
 
     public static Emoji toTripPieceEmoji(String emoji, TripPiece tripPiece) {
@@ -32,5 +34,17 @@ public class TripPieceConverter {
                 .category(tripPiece.getCategory())
                 .build();
 
+    }
+
+    public static TripPieceResponseDto.getTripPieceDto toTripPiece(TripPiece tripPiece, String countryName, String cityName, List<String> mediaUrls, String emojis) {
+        return TripPieceResponseDto.getTripPieceDto.builder()
+                .createdAt(tripPiece.getCreatedAt())
+                .countryName(countryName)
+                .cityName(cityName)
+                .category(tripPiece.getCategory())
+                .mediaUrls(mediaUrls)
+                .emojis(emojis)
+                .description(tripPiece.getDescription())
+                .build();
     }
 }

--- a/src/main/java/umc/TripPiece/service/TripPieceService.java
+++ b/src/main/java/umc/TripPiece/service/TripPieceService.java
@@ -3,6 +3,7 @@ package umc.TripPiece.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.TripPiece.converter.TripPieceConverter;
 import umc.TripPiece.domain.*;
 import umc.TripPiece.domain.enums.Category;
 import umc.TripPiece.domain.jwt.JWTUtil;
@@ -333,6 +334,44 @@ public class TripPieceService {
         return tripPieceList;
     }
 
+    @Transactional
+    public TripPieceResponseDto.getTripPieceDto getTripPiece(Long tripPieceId) {
+        TripPiece tripPiece = tripPieceRepository.getById(tripPieceId);
+        Travel travel = tripPiece.getTravel();
+        City city = travel.getCity();
+        Country country = city.getCountry();
+
+        String countryName = country.getName();
+        String cityName = city.getName();
+
+        List<String> mediaUrls = new ArrayList<>();
+        String emojis = null;
+
+        if (tripPiece.getCategory() == Category.PICTURE || tripPiece.getCategory() == Category.SELFIE)
+        {
+            List<Picture> pictures = tripPiece.getPictures();
+
+            for(Picture picture : pictures)
+            {
+                mediaUrls.add(picture.getPictureUrl());
+            }
+        }
+        else if (tripPiece.getCategory() == Category.VIDEO || tripPiece.getCategory() == Category.WHERE)
+        {
+            List<Video> videos = tripPiece.getVideos();
+
+            mediaUrls.add(videos.get(0).getVideoUrl());
+        }
+        else if (tripPiece.getCategory() == Category.EMOJI)
+        {
+            List<Emoji> emojiList = tripPiece.getEmojis();
+
+            emojis = emojiList.get(0).getEmoji() + emojiList.get(1).getEmoji() + emojiList.get(2).getEmoji() + emojiList.get(3).getEmoji();
+        }
+
+        return TripPieceConverter.toTripPiece(tripPiece, countryName, cityName, mediaUrls, emojis);
+
+    }
 
 
 }

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -2,12 +2,10 @@ package umc.TripPiece.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.TripPiece.payload.ApiResponse;
 import umc.TripPiece.service.TripPieceService;
+import umc.TripPiece.web.dto.response.TravelResponseDto;
 import umc.TripPiece.web.dto.response.TripPieceResponseDto;
 
 import java.util.List;
@@ -80,5 +78,12 @@ public class TripPieceController {
         String tokenWithoutBearer = token.substring(7);
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoListEarliest(tokenWithoutBearer);
         return ApiResponse.onSuccess(tripPieceList);
+    }
+
+    @GetMapping("mytrippieces/{tripPieceId}")
+    @Operation(summary = "단일 여행 조각 조회 API", description = "tripPieceId를 입력받아 여행 조각 출력")
+    public ApiResponse<TripPieceResponseDto.getTripPieceDto> getTripPiece(@PathVariable("tripPieceId") Long tripPieceId){
+        TripPieceResponseDto.getTripPieceDto response = tripPieceService.getTripPiece(tripPieceId);
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/umc/TripPiece/web/dto/response/TripPieceResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TripPieceResponseDto.java
@@ -4,6 +4,7 @@ import lombok.*;
 import umc.TripPiece.domain.enums.Category;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class TripPieceResponseDto {
 
@@ -19,5 +20,20 @@ public class TripPieceResponseDto {
         String cityName;
         String memo;
         String mediaUrl;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getTripPieceDto {
+        LocalDateTime createdAt;
+        String countryName;
+        String cityName;
+        Category category;
+        List<String> mediaUrls;
+        String emojis;
+        String description;
+
     }
 }


### PR DESCRIPTION
## 연관 이슈

close #43 

<br/>

## 개요

tripPieceId를 입력받아 해당 여행 조각의 정보를 받아옵니다.

<br/>

## ✅ 작업 내용

Swagger test 예시 입니다.

1) 영상
<img width="785" alt="image" src="https://github.com/user-attachments/assets/27a8d857-d3b1-48a9-a5da-b127e0868b79">

2) 사진(3장)
<img width="784" alt="image" src="https://github.com/user-attachments/assets/9d05aaa1-8ab7-4efc-9546-ebb3226f76dd">

3) 메모
<img width="782" alt="image" src="https://github.com/user-attachments/assets/61da92b9-1032-4efb-9cde-f2b52d29fb4b">

4) 이모지
<img width="788" alt="image" src="https://github.com/user-attachments/assets/d27905cd-5984-43c0-bb9c-6ffbf021c16e">


<br/>

