### PR TITLE
[feature] 카카오 로그인 및 회원가입

### DIFF
--- a/src/main/java/umc/TripPiece/converter/UserConverter.java
+++ b/src/main/java/umc/TripPiece/converter/UserConverter.java
@@ -24,10 +24,37 @@ public class UserConverter {
                 .build();
     }
 
+    public static UserResponseDto.SignUpKakaoResultDto toSignUpKakaoResultDto(User user){
+        return UserResponseDto.SignUpKakaoResultDto.builder()
+                .providerId(user.getProviderId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .gender(user.getGender())
+                .birth(user.getBirth())
+                .profileImg(user.getProfileImg())
+                .country(user.getCountry())
+                .createdAt(user.getCreatedAt() != null ? user.getCreatedAt() : LocalDateTime.now())
+                .build();
+    }
+
     public static UserResponseDto.LoginResultDto toLoginResultDto(User user, String accessToken, String refreshToken){
         return UserResponseDto.LoginResultDto.builder()
                 .email(user.getEmail())
                 .id(user.getId())
+                .nickname(user.getNickname())
+                .createdAt(user.getCreatedAt())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public static UserResponseDto.LoginKakaoResultDto toLoginKakaoResultDto(User user, String accessToken, String refreshToken){
+        return UserResponseDto.LoginKakaoResultDto.builder()
+                .providerId(user.getProviderId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .createdAt(user.getCreatedAt())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
@@ -41,6 +68,7 @@ public class UserConverter {
     }
 
 
+    /* 일반 회원가입용 */
     public static User toUser(UserRequestDto.SignUpDto request, String hashedPassword) {
         Gender gender = request.getGender();
 
@@ -55,6 +83,26 @@ public class UserConverter {
                 .country(request.getCountry())
                 .gpsConsent(true) // 고정값 설정
                 .method(UserMethod.GENERAL) // 고정값 설정
+                .isPublic(true) // 고정값 설정
+                .build();
+    }
+
+    /* 카카오 회원가입용 */
+    public static User toUser(UserRequestDto.SignUpKakaoDto request) {
+        Gender gender = request.getGender();
+
+        return User.builder()
+                .name(request.getName())
+                .email(request.getEmail())
+                .password("")
+                .nickname(request.getNickname())
+                .gender(gender)
+                .birth(request.getBirth())
+                .profileImg(request.getProfileImg())
+                .country(request.getCountry())
+                .gpsConsent(true) // 고정값 설정
+                .method(UserMethod.KAKAO) // 고정값 설정
+                .providerId(request.getProviderId()) // 카카오 providerId
                 .isPublic(true) // 고정값 설정
                 .build();
     }

--- a/src/main/java/umc/TripPiece/domain/User.java
+++ b/src/main/java/umc/TripPiece/domain/User.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="user_id", unique = true, nullable = false)
+    @Column(name="user_id", unique = true)
     private Long id;
 
     @Column(nullable = false, length = 20)
@@ -26,7 +26,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
     @Column(nullable = false, length = 20)
@@ -58,6 +58,10 @@ public class User extends BaseEntity {
     @Setter
     @Column(name = "refresh_token")
     private String refreshToken;
+
+    // 일반 가입자와 소셜 로그인 회원 구분을 위한 providerId
+    @Column(name = "provider_id", unique = true)
+    private Long providerId;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<TripPiece> tripPieces = new ArrayList<>();

--- a/src/main/java/umc/TripPiece/repository/UserRepository.java
+++ b/src/main/java/umc/TripPiece/repository/UserRepository.java
@@ -9,5 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByNickname(String nickname);
     Optional<User> findByRefreshToken(String refreshToken);
-
+    Optional<User> findByEmailAndProviderId(String email, Long providerId);
+    Optional<User> findByProviderId(Long providerId);
 }

--- a/src/main/java/umc/TripPiece/service/UserService.java
+++ b/src/main/java/umc/TripPiece/service/UserService.java
@@ -7,8 +7,14 @@ public interface UserService {
     /* 회원가입 */
     User signUp(UserRequestDto.SignUpDto request);
 
+    /* 카카오 회원가입 */
+    User signUpKakao(UserRequestDto.SignUpKakaoDto request);
+
     /* 로그인 */
     User login(UserRequestDto.LoginDto request);
+
+    /* 카카오 로그인 */
+    User loginKakao(UserRequestDto.LoginKakaoDto request);
 
     /* 토큰 재발급 */
     User reissue(UserRequestDto.ReissueDto request);

--- a/src/main/java/umc/TripPiece/web/controller/KakaoController.java
+++ b/src/main/java/umc/TripPiece/web/controller/KakaoController.java
@@ -1,0 +1,84 @@
+package umc.TripPiece.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+import umc.TripPiece.converter.UserConverter;
+import umc.TripPiece.domain.User;
+import umc.TripPiece.domain.jwt.JWTUtil;
+import umc.TripPiece.payload.ApiResponse;
+import umc.TripPiece.service.UserService;
+import umc.TripPiece.web.dto.request.UserRequestDto;
+import umc.TripPiece.web.dto.response.UserResponseDto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/user/kakao")
+public class KakaoController {
+
+    private final UserService userService;
+    private final JWTUtil jwtUtil;
+
+
+    @Autowired
+    public KakaoController(UserService userService, JWTUtil jwtUtil) {
+        this.userService = userService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @PostMapping("/signup")
+    @Operation(summary = "카카오 회원가입 API", description = "카카오 로그인 후 진행하는 회원가입")
+    public ApiResponse<UserResponseDto.SignUpKakaoResultDto> signUp(@RequestBody @Valid UserRequestDto.SignUpKakaoDto request) {
+        try {
+            User user = userService.signUpKakao(request);
+            return ApiResponse.onSuccess(UserConverter.toSignUpKakaoResultDto(user));
+        } catch (IllegalArgumentException e) {
+            return ApiResponse.onFailure("400", e.getMessage(), null);
+        }
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "카카오 로그인 API",
+    description = "카카오 계정의 존재 여부 확인")
+    public ApiResponse<UserResponseDto.LoginKakaoResultDto> login(@RequestBody @Valid UserRequestDto.LoginKakaoDto request) {
+        User user = userService.loginKakao(request);
+
+        if (user != null) {
+            // 로그인 성공 시 토큰 생성
+            String accessToken = jwtUtil.createAccessToken(request.getEmail());
+            String refreshToken = user.getRefreshToken();
+
+            return ApiResponse.onSuccess(UserConverter.toLoginKakaoResultDto(user, accessToken, refreshToken));
+        } else {
+            // 유저 정보가 없을 경우 회원가입 페이지로 이동하도록 응답
+            return ApiResponse.onFailure("404", "카카오 회원정보가 없습니다.", null);
+        }
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        String combinedMessage = String.join(" + ", errors.values());
+
+        return new ResponseEntity<>(ApiResponse.onFailure("400", combinedMessage, null), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Object>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        return new ResponseEntity<>(ApiResponse.onFailure("400", ex.getMessage(), null), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/umc/TripPiece/web/dto/request/UserRequestDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/request/UserRequestDto.java
@@ -64,4 +64,48 @@ public class UserRequestDto {
         String refreshToken;
     }
 
+    /* 카카오 회원가입 */
+    @Getter
+    @NoArgsConstructor
+    public static class SignUpKakaoDto {
+
+        @NotNull(message = "유저 ID는 필수 입력 항목입니다.")
+        private Long providerId;
+
+        @NotBlank(message = "이름은 필수 입력 항목입니다.")
+        @Size(min = 2, max = 10, message = "이름은 2자에서 10자 사이여야 합니다.")
+        private String name;
+
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        @Email(message = "유효한 이메일 주소여야 합니다.")
+        private String email;
+
+        @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자에서 10자 사이여야 합니다.")
+        private String nickname;
+
+        @NotNull(message = "성별은 필수 입력 항목입니다.")
+        private Gender gender;
+
+        @NotBlank(message = "생일은 필수 입력 항목입니다.")
+        @Pattern(regexp = "^\\d{4}/\\d{2}/\\d{2}$", message = "생일은 YYYY/MM/DD 형식이어야 합니다.")
+        private String birth;
+
+        private String profileImg;
+
+        @NotBlank(message = "국적은 필수 입력 항목입니다.")
+        @Pattern(regexp = "^South Korea$", message = "국적은 현재 대한민국만 이용 가능합니다.")
+        private String country;
+    }
+
+    /* 카카오 로그인 */
+    @Getter
+    public static class LoginKakaoDto {
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        @Email(message = "유효한 이메일 주소여야 합니다.")
+        private String email;
+
+        @NotNull(message = "유저 ID는 필수 입력 항목입니다.")
+        private Long providerId;
+    }
 }

--- a/src/main/java/umc/TripPiece/web/dto/response/UserResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/UserResponseDto.java
@@ -34,7 +34,7 @@ public class UserResponseDto {
     public static class LoginResultDto {
         Long id;
         String email;
-        String name;
+        String nickname;
         LocalDateTime createdAt;
         String accessToken;
         String refreshToken;
@@ -48,4 +48,35 @@ public class UserResponseDto {
         String accessToken;
         String refreshToken;
     }
+
+    /* 카카오 회원가입 */
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SignUpKakaoResultDto {
+        private Long providerId;
+        private String name;
+        private String email;
+        private String nickname;
+        private Gender gender;
+        private String birth;
+        private String profileImg;
+        private String country;
+        private LocalDateTime createdAt;
+    }
+
+    /* 카카오 로그인 */
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class LoginKakaoResultDto {
+        private Long providerId;
+        private String email;
+        private String nickname;
+        private LocalDateTime createdAt;
+        private String accessToken;
+        private String refreshToken;
+    }
+
 }


### PR DESCRIPTION
## 연관 이슈
close #35

<br/>

## 개요
카카오 로그인 및 회원가입

<br/>

## ✅ 작업 내용

- [x] User 도메인 내용 변경 
       : 카카오에서 발급받는 userId인 providerId 추가 및 비밀번호 nullable = false 해제
- [x] 카카오 로그인
- [x] 카카오 회원가입
- [x] 로그인 시 응답값 name → nickname 변경

<br/>

- 카카오 로그인 (회원조회) Swagger

![카카오로그인](https://github.com/user-attachments/assets/3766bb64-176f-4215-8545-118f4a07989d)

- 카카오 회원가입 Swagger

![카카오회원가입](https://github.com/user-attachments/assets/76b164c5-5afe-46cb-b8a3-992087f53e0e)

<br/>

### 📝 논의사항
- User 테이블 아래와 같이 변경되었는데, 확인하시고 이상 있다면 피드백 부탁드려요!

![image](https://github.com/user-attachments/assets/884fcc2f-9f97-4aa1-910d-d9854409214f)

- **일반 회원**의 경우에는 **user_id(id)**, **카카오 회원**의 경우에는 **providerId**로 회원 아이디가 관리됩니다! <br/>각 컬럼 내 값은 유니크한데, providerId는 프론트에서 카카오 로그인 후 제공받은 유저아이디값이라서 일반 회원의 아이디와 중복 가능성이 있어 별도 컬럼으로 분리해 관리하게 되었습니다~<br/> → 아마 이 때문에 **user_id를 사용하는 부분에서 코드 변경이 필요할 것 같아요!!<br/>확인하시고 이 부분 반영해서 코드 적용해주시면 감사드리겠습니다:)**

- 추가로 카카오 로그인에 대해서 부연설명하자면, 실질적으로 로그인은 프론트에서 진행되고, 제가 작성한 카카오 로그인 API의 경우 프론트에서 카카오 로그인 후 카카오로부터 받은 유저아이디(providerId)와 이메일을 서버에 넘겨 트립피스 자체 DB에 존재하는 유저인지를 확인하는 API라고 보시면 됩니다~!
