### PR TITLE
[fix] 카카오 유저 userId값 추가

### DIFF
--- a/src/main/java/umc/TripPiece/converter/UserConverter.java
+++ b/src/main/java/umc/TripPiece/converter/UserConverter.java
@@ -26,6 +26,7 @@ public class UserConverter {
 
     public static UserResponseDto.SignUpKakaoResultDto toSignUpKakaoResultDto(User user){
         return UserResponseDto.SignUpKakaoResultDto.builder()
+                .id(user.getId())
                 .providerId(user.getProviderId())
                 .name(user.getName())
                 .email(user.getEmail())
@@ -51,6 +52,7 @@ public class UserConverter {
 
     public static UserResponseDto.LoginKakaoResultDto toLoginKakaoResultDto(User user, String accessToken, String refreshToken){
         return UserResponseDto.LoginKakaoResultDto.builder()
+                .id(user.getId())
                 .providerId(user.getProviderId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())

--- a/src/main/java/umc/TripPiece/domain/User.java
+++ b/src/main/java/umc/TripPiece/domain/User.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="user_id", unique = true)
+    @Column(name="user_id", unique = true, nullable = false)
     private Long id;
 
     @Column(nullable = false, length = 20)

--- a/src/main/java/umc/TripPiece/web/dto/response/UserResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/UserResponseDto.java
@@ -55,6 +55,7 @@ public class UserResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SignUpKakaoResultDto {
+        private Long id;
         private Long providerId;
         private String name;
         private String email;
@@ -71,6 +72,7 @@ public class UserResponseDto {
     @Getter
     @AllArgsConstructor
     public static class LoginKakaoResultDto {
+        private Long id;
         private Long providerId;
         private String email;
         private String nickname;


### PR DESCRIPTION
## 연관 이슈

close #35

<br/>

## 개요
카카오 유저 userId값 추가

<br/>

## ✅ 작업 내용

- [x] 카카오 유저 userId값 추가
<br/>

![image](https://github.com/user-attachments/assets/e734ae7f-7869-4e08-9c9d-7c3de7447781)

![image](https://github.com/user-attachments/assets/ec4be7d1-9dd0-497f-975d-53e661942a9b)


### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 이전 PR에서 providerId 반영해야 한다는 내용은 무시해주세요! 카카오 유저의 경우도 일반 유저와 마찬가지로 userId(id)를 부여해 사용하도록 변경했고, providerId는 유저 조회용으로만 사용하려합니다!
