### PR TITLE
[refactor] 프로필 변경 시 프로필 사진 필수에서 선택으로 변경

### DIFF
--- a/src/main/java/umc/TripPiece/converter/UserConverter.java
+++ b/src/main/java/umc/TripPiece/converter/UserConverter.java
@@ -124,6 +124,7 @@ public class UserConverter {
                 .nickname(user.getNickname())
                 .gender(user.getGender())
                 .birth(user.getBirth())
+                .country(user.getCountry())
                 .profileImg(user.getProfileImg())
                 .build();
     }

--- a/src/main/java/umc/TripPiece/service/UserServiceImpl.java
+++ b/src/main/java/umc/TripPiece/service/UserServiceImpl.java
@@ -201,12 +201,18 @@ public class UserServiceImpl implements UserService{
         Uuid savedUuid = uuidRepository.save(Uuid.builder()
                 .uuid(uuid).build());
 
-        String profileImgUrl = s3Manager.uploadFile(s3Manager.generateTripPieceKeyName(savedUuid), profileImg);
-
         Long userId = jwtUtil.getUserIdFromToken(token);
         User user = userRepository.findById(userId).orElseThrow(() ->
                 new IllegalArgumentException("존재하지 않는 계정입니다.")
         );
+
+        String profileImgUrl;
+
+        if(profileImg == null) {
+            profileImgUrl = user.getProfileImg();
+        } else {
+            profileImgUrl = s3Manager.uploadFile(s3Manager.generateTripPieceKeyName(savedUuid), profileImg);
+        }
 
         if(request.getNickname() != null){
             user.updatenickname(request.getNickname());

--- a/src/main/java/umc/TripPiece/web/controller/UserController.java
+++ b/src/main/java/umc/TripPiece/web/controller/UserController.java
@@ -100,7 +100,7 @@ public class UserController {
     @PostMapping(value = "/update", consumes = "multipart/form-data")
     @Operation(summary = "프로필 수정하기 API",
             description = "프로필 수정하기")
-    public ApiResponse<UserResponseDto.UpdateResultDto> update(@RequestPart("info") @Valid UserRequestDto.UpdateDto request, @RequestHeader("Authorization") String token, @RequestPart("profileImg") MultipartFile profileImg) {
+    public ApiResponse<UserResponseDto.UpdateResultDto> update(@RequestPart("info") @Valid UserRequestDto.UpdateDto request, @RequestHeader("Authorization") String token, @RequestPart(value = "profileImg", required = false) MultipartFile profileImg) {
         String tokenWithoutBearer = token.substring(7);
         User user = userService.update(request, tokenWithoutBearer, profileImg);
 


### PR DESCRIPTION
## 연관 이슈

#48 

<br/>

## 개요

프로필 사진 변경 시 사진 입력 필수에서 선택으로 변경

<br/>

## ✅ 작업 내용
<img width="787" alt="image" src="https://github.com/user-attachments/assets/fb7df023-ba5f-4b9b-9185-992f8c671d6d">

- 프로필 사진 없이 프로필 변경 시 이전의 프로필 사진으로 설정되게 하였음
- 국적 변경 시 반영 안되던 오류 수정함


