### PR TITLE
[feature] 여행 조각 수정 API 구현

### DIFF
--- a/src/main/java/umc/TripPiece/domain/TripPiece.java
+++ b/src/main/java/umc/TripPiece/domain/TripPiece.java
@@ -21,6 +21,7 @@ public class TripPiece extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'MEMO'")
     private Category category;
@@ -32,6 +33,7 @@ public class TripPiece extends BaseEntity {
     @ColumnDefault("true")
     private Boolean travel_contain;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "travel_id")
     private Travel travel;
@@ -49,11 +51,23 @@ public class TripPiece extends BaseEntity {
     @OneToMany(mappedBy = "tripPiece", cascade = CascadeType.ALL)
     private List<Emoji> emojis = new ArrayList<>();
 
-    public void setCategory(Category category) {
-        this.category = category;
+    public void updateMemo(String description) {
+        this.description = description;
     }
 
-    public void setTravel(Travel travel) {
-        this.travel = travel;
+    public void updatePicture(String description, List<Picture> pictures) {
+        this.description = description;
+        this.pictures = pictures;
     }
+
+    public void updateVideo(String description, List<Video> videos) {
+        this.description = description;
+        this.videos = videos;
+    }
+
+    public void updateEmoji(String description, List<Emoji> emojis) {
+        this.description = description;
+        this.emojis = emojis;
+    }
+
 }

--- a/src/main/java/umc/TripPiece/service/TripPieceService.java
+++ b/src/main/java/umc/TripPiece/service/TripPieceService.java
@@ -12,6 +12,7 @@ import umc.TripPiece.repository.PictureRepository;
 import umc.TripPiece.repository.TripPieceRepository;
 import umc.TripPiece.repository.UserRepository;
 import umc.TripPiece.repository.VideoRepository;
+import umc.TripPiece.web.dto.request.TripPieceRequestDto;
 import umc.TripPiece.web.dto.response.TripPieceResponseDto;
 
 import java.util.ArrayList;
@@ -396,6 +397,47 @@ public class TripPieceService {
         // 여행 조각 삭제
         TripPiece tripPiece = tripPieceRepository.getById(id);
         tripPieceRepository.delete(tripPiece);
+    }
+
+    /* 여행 조각 수정 */
+    @Transactional
+    public Long memoUpdate(Long id, TripPieceRequestDto.MemoUpdateDto memoUpdateDto) {
+        TripPiece tripPiece = tripPieceRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("TripPiece not found"));
+
+        tripPiece.updateMemo(memoUpdateDto.getDescription());
+
+        return id;
+    }
+
+    @Transactional
+    public Long pictureUpdate(Long id, TripPieceRequestDto.PictureUpdateDto pictureUpdateDto) {
+        TripPiece tripPiece = tripPieceRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("TripPiece not found"));
+
+        tripPiece.updatePicture(pictureUpdateDto.getDescription(), pictureUpdateDto.getPictures());
+
+        return id;
+    }
+
+    @Transactional
+    public Long videoUpdate(Long id, TripPieceRequestDto.VideoUpdateDto videoUpdateDto) {
+        TripPiece tripPiece = tripPieceRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("TripPiece not found"));
+
+        tripPiece.updateVideo(videoUpdateDto.getDescription(), videoUpdateDto.getVideos());
+
+        return id;
+    }
+
+    @Transactional
+    public Long emojiUpdate(Long id, TripPieceRequestDto.EmojiUpdateDto emojiUpdateDto) {
+        TripPiece tripPiece = tripPieceRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("TripPiece not found"));
+
+        tripPiece.updateEmoji(emojiUpdateDto.getDescription(), emojiUpdateDto.getEmojis());
+
+        return id;
     }
 
 }

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import umc.TripPiece.payload.ApiResponse;
 import umc.TripPiece.repository.TripPieceRepository;
 import umc.TripPiece.service.TripPieceService;
+import umc.TripPiece.web.dto.request.TripPieceRequestDto;
 import umc.TripPiece.web.dto.response.TripPieceResponseDto;
 
 import java.util.List;
@@ -113,5 +114,11 @@ public class TripPieceController {
             tripPieceService.delete(tripPieceId);
             return ApiResponse.onSuccess(null);
         }
+    }
+
+    @PatchMapping("/mytrippieces/memo/{tripPieceId}/update")
+    @Operation(summary = "여행 조각(메모) 수정 API", description = "memo 타입의 tripPiece 수정")
+    public ApiResponse<Long> updateMemo(@PathVariable("tripPieceId") Long tripPieceId, @RequestBody TripPieceRequestDto.MemoUpdateDto request){
+        return ApiResponse.onSuccess(tripPieceService.memoUpdate(tripPieceId, request));
     }
 }

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -3,6 +3,7 @@ package umc.TripPiece.web.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import umc.TripPiece.payload.ApiResponse;
 import umc.TripPiece.repository.TripPieceRepository;
 import umc.TripPiece.service.TripPieceService;
@@ -118,7 +119,25 @@ public class TripPieceController {
 
     @PatchMapping("/mytrippieces/memo/{tripPieceId}/update")
     @Operation(summary = "여행 조각(메모) 수정 API", description = "memo 타입의 tripPiece 수정")
-    public ApiResponse<Long> updateMemo(@PathVariable("tripPieceId") Long tripPieceId, @RequestBody TripPieceRequestDto.MemoUpdateDto request){
+    public ApiResponse<Long> updateMemo(@PathVariable("tripPieceId") Long tripPieceId, @RequestBody TripPieceRequestDto.update request){
         return ApiResponse.onSuccess(tripPieceService.memoUpdate(tripPieceId, request));
+    }
+
+    @PatchMapping(value = "/mytrippieces/picture/{tripPieceId}/update", consumes = "multipart/form-data")
+    @Operation(summary = "여행 조각(사진) 수정 API", description = "picture 타입의 tripPiece 수정")
+    public ApiResponse<Long> updatePicture(@PathVariable("tripPieceId") Long tripPieceId, @RequestPart TripPieceRequestDto.update request, @RequestPart("picture") List<MultipartFile> pictures){
+        return ApiResponse.onSuccess(tripPieceService.pictureUpdate(tripPieceId, request, pictures));
+    }
+
+    @PatchMapping(value = "/mytrippieces/video/{tripPieceId}/update", consumes = "multipart/form-data")
+    @Operation(summary = "여행 조각(영상) 수정 API", description = "video 타입의 tripPiece 수정")
+    public ApiResponse<Long> updateVideo(@PathVariable("tripPieceId") Long tripPieceId, @RequestPart TripPieceRequestDto.update request, @RequestPart("video") MultipartFile video){
+        return ApiResponse.onSuccess(tripPieceService.videoUpdate(tripPieceId, request, video));
+    }
+
+    @PatchMapping("/mytrippieces/emoji/{tripPieceId}/update")
+    @Operation(summary = "여행 조각(이모지) 수정 API", description = "emoji 타입의 tripPiece 수정")
+    public ApiResponse<Long> updateEmoji(@PathVariable("tripPieceId") Long tripPieceId, @RequestBody TripPieceRequestDto.update request, @RequestPart("emoji") List<String> emojis){
+        return ApiResponse.onSuccess(tripPieceService.emojiUpdate(tripPieceId, request, emojis));
     }
 }

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -104,7 +104,7 @@ public class TripPieceController {
         return ApiResponse.onSuccess(response);
     }
 
-    @DeleteMapping("/mytrippieces/{tripPieceId}")
+    @DeleteMapping("/mytrippieces/{tripPieceId}/delete")
     @Operation(summary = "여행 조각 삭제 API", description = "tripPieceId를 입력 받아 해당 여행 조각을 삭제")
     public ApiResponse<Object> deleteTripPiece(@PathVariable("tripPieceId") Long tripPieceId){
         if (!tripPieceRepository.existsById(tripPieceId))

--- a/src/main/java/umc/TripPiece/web/dto/request/TripPieceRequestDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/request/TripPieceRequestDto.java
@@ -1,0 +1,38 @@
+package umc.TripPiece.web.dto.request;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.TripPiece.domain.Emoji;
+import umc.TripPiece.domain.Picture;
+import umc.TripPiece.domain.Video;
+
+public class TripPieceRequestDto {
+  @Getter
+  @NoArgsConstructor
+  public static class MemoUpdateDto {
+    String description;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  public static class PictureUpdateDto {
+    String description;
+    List<Picture> pictures;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  public static class VideoUpdateDto {
+    String description;
+    List<Video> videos;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  public static class EmojiUpdateDto {
+    String description;
+    List<Emoji> emojis;
+  }
+
+}

--- a/src/main/java/umc/TripPiece/web/dto/request/TripPieceRequestDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/request/TripPieceRequestDto.java
@@ -1,38 +1,13 @@
 package umc.TripPiece.web.dto.request;
 
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import umc.TripPiece.domain.Emoji;
-import umc.TripPiece.domain.Picture;
-import umc.TripPiece.domain.Video;
 
 public class TripPieceRequestDto {
   @Getter
   @NoArgsConstructor
-  public static class MemoUpdateDto {
+  public static class update {
     String description;
-  }
-
-  @Getter
-  @NoArgsConstructor
-  public static class PictureUpdateDto {
-    String description;
-    List<Picture> pictures;
-  }
-
-  @Getter
-  @NoArgsConstructor
-  public static class VideoUpdateDto {
-    String description;
-    List<Video> videos;
-  }
-
-  @Getter
-  @NoArgsConstructor
-  public static class EmojiUpdateDto {
-    String description;
-    List<Emoji> emojis;
   }
 
 }


### PR DESCRIPTION
## 개요

여행 조각 수정 API 구현

4가지 타입(사진, 영상, 이모지, 메모)의 수정 API 구현 완료

각 타입에 맞는 여행 조각만 수정 가능
<br/>

## ✅ 작업 내용

여행조각(사진) update

<img width="552" alt="image" src="https://github.com/user-attachments/assets/852c6a15-6085-4fb1-8334-c18ffe407a2e">

<br/>

### 📝 논의사항

예외처리는 간단하게 해놓았고 추 후 수정 예정

마찬가지로 수정하면 이전의 데이터는 모두 삭제됨

그리고 여행조각 수정에 대한 명확한 기준이 필요해보임
여행조각의 카테고리(사진,영상,이모지)를 바꿀 수 있는지, 설명만 바꿀 수 있는지 등...