### PR TITLE
[feature] 회원탈퇴

### DIFF
--- a/src/main/java/umc/TripPiece/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/umc/TripPiece/aws/s3/AmazonS3Manager.java
@@ -1,6 +1,7 @@
 package umc.TripPiece.aws.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
@@ -64,6 +65,17 @@ public class AmazonS3Manager{
 
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
     }
+
+    public void deleteFile(String keyName) {
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(amazonConfig.getBucket(), keyName));
+            log.info("Successfully deleted file: {}", keyName);
+        } catch (Exception e) {
+            log.error("Error deleting file from S3: {}", keyName, e);
+            throw new IllegalStateException("Failed to delete file from S3", e);
+        }
+    }
+
 
     public String generateTripPieceKeyName(Uuid uuid) {
         return amazonConfig.getTripPiecePath() + '/' + uuid.getUuid();

--- a/src/main/java/umc/TripPiece/domain/User.java
+++ b/src/main/java/umc/TripPiece/domain/User.java
@@ -62,6 +62,10 @@ public class User extends BaseEntity {
     @ColumnDefault("false")
     private Boolean isPublic;
 
+    @OneToOne
+    @JoinColumn(name = "uuid_id")
+    private Uuid uuid;
+
     public void updatenickname(String nickname) {
         this.nickname = nickname;
     }
@@ -89,4 +93,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<TripPiece> tripPieces = new ArrayList<>();
 
+    public Uuid getUuid() {
+        return this.uuid;
+    }
 }

--- a/src/main/java/umc/TripPiece/domain/Uuid.java
+++ b/src/main/java/umc/TripPiece/domain/Uuid.java
@@ -15,6 +15,6 @@ public class Uuid extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private String uuid;
 }

--- a/src/main/java/umc/TripPiece/repository/UserRepository.java
+++ b/src/main/java/umc/TripPiece/repository/UserRepository.java
@@ -2,6 +2,7 @@ package umc.TripPiece.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.TripPiece.domain.User;
+import umc.TripPiece.domain.Uuid;
 
 import java.util.Optional;
 
@@ -11,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByRefreshToken(String refreshToken);
     Optional<User> findByEmailAndProviderId(String email, Long providerId);
     Optional<User> findByProviderId(Long providerId);
+    Optional<User> findByUuid(Uuid uuid);
 }

--- a/src/main/java/umc/TripPiece/service/UserService.java
+++ b/src/main/java/umc/TripPiece/service/UserService.java
@@ -25,6 +25,9 @@ public interface UserService {
     /* 로그아웃 */
     void logout(Long userId);
 
+    /* 회원탈퇴 */
+    void withdrawal(Long userId);
+
     User save(User user);
 
     /* 수정하기 */

--- a/src/main/java/umc/TripPiece/web/controller/UserController.java
+++ b/src/main/java/umc/TripPiece/web/controller/UserController.java
@@ -90,8 +90,29 @@ public class UserController {
         String token = header.substring(7);
         try {
             Long userId = jwtUtil.getUserIdFromToken(token);
+            if (userId==null) return ApiResponse.onFailure("400", "존재하지 않거나 만료된 토큰입니다.", null);
             userService.logout(userId);
             return ApiResponse.onSuccess("로그아웃에 성공했습니다.");
+        } catch (Exception e) {
+            return ApiResponse.onFailure("400", e.getMessage(), null);
+        }
+    }
+
+    @DeleteMapping("/withdrawal")
+    @Operation(summary = "회원탈퇴 API", description = "회원탈퇴")
+    public ApiResponse<String> withdrawal(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            return ApiResponse.onFailure("400", "토큰이 유효하지 않습니다.", null);
+        }
+
+        String token = header.substring(7);
+
+        try {
+            Long userId = jwtUtil.getUserIdFromToken(token);
+            if (userId==null) return ApiResponse.onFailure("400", "존재하지 않거나 만료된 토큰입니다.", null);
+            userService.withdrawal(userId);
+            return ApiResponse.onSuccess("회원탈퇴에 성공했습니다.");
         } catch (Exception e) {
             return ApiResponse.onFailure("400", e.getMessage(), null);
         }


### PR DESCRIPTION
## 연관 이슈

close #76

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
회원탈퇴
<br/>

## ✅ 작업 내용

- [x] User 도메인과 uuid 연결
- [x] AmazonS3Manager에 deleteFile() 추가
- [x] 회원탈퇴 API 기능 구현
      (회원탈퇴 시 유저 정보 및 여행 정보, uuid, S3에서의 프로필 이미지 삭제)

![image](https://github.com/user-attachments/assets/e08d6d28-6293-4cf7-9d51-e75b15139d99)

![image](https://github.com/user-attachments/assets/1ebe2e17-c172-4db8-8a05-1222bf3d1934)

![image](https://github.com/user-attachments/assets/c805b4d9-d30f-4c52-badc-2564f241d8b2)

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
@StoneCAU uuid가 어떤 용도인지 좀 헷갈려서.. User랑 일대일 매핑하고 회원탈퇴 시에 삭제되게 했는데 맞을까요? 회원가입 시에 uuid가 프로필 이미지 일련번호 생성라고 주석되어있던데 이 일련번호가 왜 필요한지 궁금했습니다!
