### PR TITLE
[feature] 이메일 인증 관련 API 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation('org.projectlombok:lombok')
+	/* Email 전송 관련 */
+    implementation 'org.springframework.boot:spring-boot-starter-mail:3.1.2'
+
+    /* 메일 HTML 작성 관련 */
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/TripPiece/config/EmailConfig.java
+++ b/src/main/java/umc/TripPiece/config/EmailConfig.java
@@ -1,0 +1,73 @@
+package umc.TripPiece.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import umc.TripPiece.service.EmailService;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public EmailService emailService() {
+        return new EmailService(javaMailSender());
+    }
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/umc/TripPiece/domain/VerificationCode.java
+++ b/src/main/java/umc/TripPiece/domain/VerificationCode.java
@@ -1,0 +1,31 @@
+package umc.TripPiece.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class VerificationCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String code;
+    private LocalDateTime expirationTime;
+
+    public VerificationCode(String email, String code, int expirationMinutes) {
+        this.email = email;
+        this.code = code;
+        this.expirationTime = LocalDateTime.now().plusMinutes(expirationMinutes);
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expirationTime);
+    }
+}

--- a/src/main/java/umc/TripPiece/repository/VerificationCodeRepository.java
+++ b/src/main/java/umc/TripPiece/repository/VerificationCodeRepository.java
@@ -1,0 +1,12 @@
+package umc.TripPiece.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.TripPiece.domain.VerificationCode;
+
+import java.util.Optional;
+
+@Repository
+public interface VerificationCodeRepository extends JpaRepository<VerificationCode, Long> {
+    Optional<VerificationCode> findByEmail(String email);
+}

--- a/src/main/java/umc/TripPiece/repository/VerificationCodeRepository.java
+++ b/src/main/java/umc/TripPiece/repository/VerificationCodeRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface VerificationCodeRepository extends JpaRepository<VerificationCode, Long> {
-    Optional<VerificationCode> findByEmail(String email);
+    Optional<VerificationCode> findTopByEmailOrderByExpirationTimeDesc(String email);
 }

--- a/src/main/java/umc/TripPiece/service/EmailService.java
+++ b/src/main/java/umc/TripPiece/service/EmailService.java
@@ -1,0 +1,48 @@
+package umc.TripPiece.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Random;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender emailSender;
+
+    public String generateVerificationCode() {
+        Random random = new Random();
+        int code = 100000 + random.nextInt(900000); // 6자리 숫자 생성
+        return String.valueOf(code);
+    }
+
+    public void sendVerificationCode(String toEmail, String code) throws MessagingException {
+        String subject = "이메일 인증 코드";
+        String content = "<p>아래의 인증 코드를 입력하세요:</p>" +
+                "<h3>" + code + "</h3>";
+        sendEmail(toEmail, subject, content);
+    }
+
+    public void sendEmail(String toEmail, String title, String content) throws MessagingException {
+        MimeMessage message = emailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true);
+        helper.setTo(toEmail);
+        helper.setSubject(title);
+        helper.setText(content, true); // HTML 사용 가능
+        try {
+            emailSender.send(message);
+        } catch (RuntimeException e) {
+            log.error("Failed to send email", e);
+            throw new RuntimeException("Unable to send email", e);
+        }
+    }
+}

--- a/src/main/java/umc/TripPiece/service/EmailService.java
+++ b/src/main/java/umc/TripPiece/service/EmailService.java
@@ -9,6 +9,9 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Random;
 
 @Slf4j
@@ -25,11 +28,29 @@ public class EmailService {
         return String.valueOf(code);
     }
 
-    public void sendVerificationCode(String toEmail, String code) throws MessagingException {
-        String subject = "이메일 인증 코드";
-        String content = "<p>아래의 인증 코드를 입력하세요:</p>" +
-                "<h3>" + code + "</h3>";
+    public void sendVerificationCode(String toEmail, String code) throws MessagingException, IOException {
+        String subject = "[여행조각(TripPiece)] 회원가입 시 이메일 인증번호 안내드립니다.";
+
+        // HTML 파일을 읽고 코드 삽입
+        String content;
+        try {
+            content = getEmailHtmlContent(code);
+        } catch (IOException e) {
+            log.error("Failed to read email template", e);
+            throw new MessagingException("이메일 템플릿을 읽는 중 오류가 발생했습니다.");
+        }
+
         sendEmail(toEmail, subject, content);
+    }
+
+    private String getEmailHtmlContent(String code) throws IOException {
+        String htmlTemplatePath = "src/main/resources/templates/email.html";
+        String content = new String(Files.readAllBytes(Paths.get(htmlTemplatePath)));
+
+        // 인증 코드 삽입
+        content = content.replace("{code}", code);
+
+        return content;
     }
 
     public void sendEmail(String toEmail, String title, String content) throws MessagingException {
@@ -37,12 +58,11 @@ public class EmailService {
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
         helper.setTo(toEmail);
         helper.setSubject(title);
-        helper.setText(content, true); // HTML 사용 가능
+        helper.setText(content, true);
         try {
             emailSender.send(message);
         } catch (RuntimeException e) {
-            log.error("Failed to send email", e);
-            throw new RuntimeException("Unable to send email", e);
+            throw new RuntimeException("이메일 전송 불가", e);
         }
     }
 }

--- a/src/main/java/umc/TripPiece/web/controller/CityController.java
+++ b/src/main/java/umc/TripPiece/web/controller/CityController.java
@@ -1,16 +1,13 @@
 package umc.TripPiece.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.TripPiece.payload.ApiResponse;
 import umc.TripPiece.service.CityService;
@@ -19,6 +16,7 @@ import umc.TripPiece.web.dto.response.CityResponseDto;
 
 import java.util.List;
 
+@Tag(name = "City", description = "도시 관련 API")
 @RestController
 @RequiredArgsConstructor
 public class CityController {

--- a/src/main/java/umc/TripPiece/web/controller/EmailController.java
+++ b/src/main/java/umc/TripPiece/web/controller/EmailController.java
@@ -15,6 +15,7 @@ import umc.TripPiece.repository.VerificationCodeRepository;
 import umc.TripPiece.service.EmailService;
 import umc.TripPiece.web.dto.request.EmailRequestDto;
 
+import java.io.IOException;
 import java.util.Optional;
 
 @Tag(name = "Email", description = "이메일 인증 관련 API")
@@ -46,6 +47,8 @@ public class EmailController {
             emailService.sendVerificationCode(email, code);
         } catch (MessagingException e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.onFailure("500", "이메일 전송에 실패했습니다.", null));
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.onFailure("500", "이메일 템플릿을 읽는 중 오류가 발생했습니다.", null));
         }
 
         return ResponseEntity.ok(ApiResponse.onSuccess("해당 이메일로 인증번호를 전송했습니다."));

--- a/src/main/java/umc/TripPiece/web/controller/EmailController.java
+++ b/src/main/java/umc/TripPiece/web/controller/EmailController.java
@@ -1,0 +1,79 @@
+package umc.TripPiece.web.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.mail.MessagingException;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import umc.TripPiece.domain.VerificationCode;
+import umc.TripPiece.payload.ApiResponse;
+import umc.TripPiece.repository.VerificationCodeRepository;
+import umc.TripPiece.service.EmailService;
+import umc.TripPiece.web.dto.request.EmailRequestDto;
+
+import java.util.Optional;
+
+@Tag(name = "Email", description = "이메일 인증 관련 API")
+@RestController
+@RequestMapping("/email")
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final EmailService emailService;
+    private final VerificationCodeRepository verificationCodeRepository;
+
+    @PostMapping("/send")
+    @Operation(summary = "이메일 인증번호 전송 API",
+            description = "이메일로 6자리 인증번호 발송")
+    public ResponseEntity<ApiResponse<String>> sendVerificationCode(@RequestBody EmailRequestDto.SendCodeDto request) {
+        String email = request.getEmail();
+
+        // 이메일 주소 유효성 체크
+        if (!isValidEmail(email)) {
+            return ResponseEntity.badRequest().body(ApiResponse.onFailure("400", "유효한 이메일 주소여야 합니다.", null));
+        }
+
+        String code = emailService.generateVerificationCode();
+
+        VerificationCode verificationCode = new VerificationCode(request.getEmail(), code, 3); // 인증코드 유효시간 (3분)
+        verificationCodeRepository.save(verificationCode);
+
+        try {
+            emailService.sendVerificationCode(email, code);
+        } catch (MessagingException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.onFailure("500", "이메일 전송에 실패했습니다.", null));
+        }
+
+        return ResponseEntity.ok(ApiResponse.onSuccess("해당 이메일로 인증번호를 전송했습니다."));
+    }
+
+    @PostMapping("/verify")
+    @Operation(summary = "이메일 인증번호 검증 API",
+            description = "이메일로 발송된 인증번호의 일치 여부 검증")
+    public ResponseEntity<ApiResponse<String>> verifyCode(@RequestBody EmailRequestDto.VerifyCodeDto request) {
+        Optional<VerificationCode> optionalCode = verificationCodeRepository.findByEmail(request.getEmail());
+
+        if (optionalCode.isEmpty()) {
+            return ResponseEntity.badRequest().body(ApiResponse.onFailure("400", "인증코드가 발송되지 않은 이메일입니다.", null));
+        }
+
+        VerificationCode verificationCode = optionalCode.get();
+
+        if (verificationCode.isExpired()) {
+            return ResponseEntity.badRequest().body(ApiResponse.onFailure("400", "이메일 인증 시간인 3분을 초과했습니다.", null));
+        }
+
+        if (!verificationCode.getCode().equals(request.getCode())) {
+            return ResponseEntity.badRequest().body(ApiResponse.onFailure("400", "인증번호가 일치하지 않습니다.", null));
+        }
+
+        return ResponseEntity.ok(ApiResponse.onSuccess("이메일 인증에 성공했습니다."));
+    }
+
+    private boolean isValidEmail(String email) {
+        String emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*\\.(com|net|org|co\\.kr|ac\\.kr|gov|edu)$";
+        return email.matches(emailRegex);
+    }
+}

--- a/src/main/java/umc/TripPiece/web/controller/KakaoController.java
+++ b/src/main/java/umc/TripPiece/web/controller/KakaoController.java
@@ -1,7 +1,7 @@
 package umc.TripPiece.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -21,6 +21,7 @@ import umc.TripPiece.web.dto.response.UserResponseDto;
 import java.util.HashMap;
 import java.util.Map;
 
+@Tag(name = "Kakao", description = "카카오 유저 관련 API")
 @RestController
 @RequestMapping("/user/kakao")
 public class KakaoController {

--- a/src/main/java/umc/TripPiece/web/controller/MapController.java
+++ b/src/main/java/umc/TripPiece/web/controller/MapController.java
@@ -1,18 +1,18 @@
 package umc.TripPiece.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-import umc.TripPiece.service.TripPieceService;
 import umc.TripPiece.web.dto.request.MapRequestDto;
 import umc.TripPiece.web.dto.response.ApiResponse;
 import umc.TripPiece.web.dto.response.MapResponseDto;
 import umc.TripPiece.service.MapService;
 import umc.TripPiece.web.dto.response.MapStatsResponseDto;
-import umc.TripPiece.web.dto.response.TripPieceResponseDto;
 
 import java.util.List;
 
+@Tag(name = "Map", description = "지도 관련 API")
 @RestController
 @RequestMapping("/api/maps")
 public class MapController {

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -1,11 +1,10 @@
 package umc.TripPiece.web.controller;
 
-
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,6 +22,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@Tag(name = "Travel", description = "여행기 관련 API")
 @RestController
 @RequiredArgsConstructor
 public class TravelController {

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -1,6 +1,7 @@
 package umc.TripPiece.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,6 +13,7 @@ import umc.TripPiece.web.dto.response.TripPieceResponseDto;
 
 import java.util.List;
 
+@Tag(name = "TripPiece", description = "여행 조각 관련 API")
 @RestController
 @RequiredArgsConstructor
 public class TripPieceController {

--- a/src/main/java/umc/TripPiece/web/controller/UserController.java
+++ b/src/main/java/umc/TripPiece/web/controller/UserController.java
@@ -1,6 +1,7 @@
 package umc.TripPiece.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,8 +21,8 @@ import umc.TripPiece.web.dto.response.UserResponseDto;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
+@Tag(name = "User", description = "유저 관련 API")
 @RestController
 @RequestMapping("/user")
 public class UserController {

--- a/src/main/java/umc/TripPiece/web/dto/request/EmailRequestDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/request/EmailRequestDto.java
@@ -1,0 +1,32 @@
+package umc.TripPiece.web.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class EmailRequestDto {
+
+    /* 인증 코드 요청 */
+    @Getter
+    @NoArgsConstructor
+    public static class SendCodeDto {
+
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        @Email(message = "유효한 이메일 주소여야 합니다.")
+        private String email;
+    }
+
+    /* 인증 코드 검증 */
+    @Getter
+    @NoArgsConstructor
+    public static class VerifyCodeDto {
+
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        @Email(message = "유효한 이메일 주소여야 합니다.")
+        private String email;
+
+        @NotBlank(message = "인증 코드는 필수 입력 항목입니다.")
+        @Size(min = 6, max = 6, message = "인증 코드는 6자리여야 합니다.")
+        private String code;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,22 @@ spring:
         jdbc:
           time_zone: Asia/Seoul
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          timeout: 5000
+          connectiontimeout: 5000
+          writetimeout: 5000
+
 springdoc:
   swagger-ui:
     path: /swagger

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>여행조각 이메일 인증</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <table
+      style="
+        width: 1200px;
+        box-sizing: border-box;
+        border-collapse: collapse;
+        background-color: #ffffff;
+        text-align: left;
+        margin: 0 auto;
+      "
+    >
+      <tbody>
+        <tr>
+          <td>
+            <table
+              cellpadding="0"
+              cellspacing="0"
+              style="
+                width: 1200px;
+                height: 182px;
+                background: #6644ff;
+                padding: 52px 563px;
+              "
+            >
+              <tr>
+                <td style="padding-bottom: 11.61px">
+                  <img
+                    src="https://ifh.cc/g/kTZ30H.png"
+                    style="display: block"
+                    width="74"
+                    height="77"
+                    alt="여행조각"
+                  />
+                </td>
+              </tr>
+            </table>
+            <table
+              cellpadding="0"
+              cellspacing="0"
+              style="width: 1200px; height: 514px; padding: 66px 95px 45px 95px"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <span
+                      style="
+                        color: #7e7e7e;
+                        font-family: Pretendard;
+                        font-size: 28px;
+                        font-style: normal;
+                        font-weight: 500;
+                        line-height: 150%;
+                      "
+                    >
+                      안녕하세요 여행조각에서 요청하신 인증번호를 보내드립니다
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding-top: 76px">
+                    <span
+                      style="
+                        color: #353535;
+                        font-size: 48px;
+                        font-style: normal;
+                        font-weight: 600;
+                        line-height: 150%;
+                      "
+                    >
+                      {code}
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding-top: 103px">
+                    <span
+                      style="
+                        color: #7e7e7e;
+                        font-family: Pretendard;
+                        font-size: 28px;
+                        font-style: normal;
+                        font-weight: 500;
+                        line-height: 150%;
+                      "
+                    >
+                      위 인증번호 6자리를 인증번호 입력창에 입력해주세요
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding-top: 48px">
+                    <span
+                      style="
+                        color: #979797;
+                        font-family: Pretendard;
+                        font-size: 18px;
+                        font-style: normal;
+                        font-weight: 400;
+                        line-height: 150%;
+                      "
+                    >
+                      본인이 인증번호를 요청하지 않았을 경우 본 이메일을
+                      무시해주세요.<br />
+                      Please ignore this email if you did not request a
+                      verification code<br />
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              cellpadding="0"
+              cellspacing="0"
+              style="width: 1200px; height: 182px; background: #6644ff"
+            ></table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
## 연관 이슈

close #79

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
이메일 인증번호 발송 및 검증 API 기능 구현
<br/>

## ✅ 작업 내용
- [x] 이메일 인증번호 발송 및 검증 API
(인증코드 유효시간, 인증메인 안 보낸 이메일에 대한 에러 메세지 반환, 이메일 및 인증 코드 유효성 검사 등 반영)
- [x] Swagger Controller 문서 설명 작성
- [x] 동일 이메일 인증코드 여러 개 존재 시 오류 수정, 인증번호 길이 유효성 검사 추가
- [x] 이메일 인증 HTML 템플릿 추가

- 이메일 인증번호 발송
![image](https://github.com/user-attachments/assets/d78e6400-30ad-4656-9ebb-6352b1f08e0a)

- 이메일 인증번호 검증
![image](https://github.com/user-attachments/assets/42c7e269-f2fb-424c-b6b0-3b370f8d9d43)
![image](https://github.com/user-attachments/assets/d77e9b77-c1a3-4f97-9430-64cb0c731aaf)
![image](https://github.com/user-attachments/assets/b566d31e-3e67-4824-827c-6fdd47a36c71)

- 받은 이메일 화면
![image](https://github.com/user-attachments/assets/a1158eae-c1e3-418c-8656-24d3d68fb387)

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
추가된 환경 변수 정보는 **Notion>백엔드>.env**에 적어두었으니 확인해주세요!
