### PR TITLE
[refactor] 여행기 조각 정렬 및 프로필 수정 API 리팩토링

### DIFF
--- a/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
@@ -18,9 +18,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // Not Found
-    NOT_FOUND_MAP(HttpStatus.NOT_FOUND, "MAP400", "해당 맵을 찾을 수 없습니다."),
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER400", "해당 유저를 찾을 수 없습니다."),
-    NOT_FOUND_CITY(HttpStatus.NOT_FOUND, "CITY400", "해당 도시를 찾을 수 없습니다."),
+    NOT_FOUND_MAP(HttpStatus.NOT_FOUND, "MAP404", "해당 맵을 찾을 수 없습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER404", "해당 유저를 찾을 수 없습니다."),
+    NOT_FOUND_CITY(HttpStatus.NOT_FOUND, "CITY404", "해당 도시를 찾을 수 없습니다."),
 
     // s3 관련 오류
     PICTURE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "PICTURE400", "이미지의 확장자가 잘못되었습니다."),
@@ -41,7 +41,7 @@ public enum ErrorStatus implements BaseErrorCode {
     PROFILE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PROFILE500", "프로필 업데이트에 실패했습니다."),
 
     // 여행 조각 관련 오류
-    NOT_FOUND_TRIPPIECE(HttpStatus.NOT_FOUND, "TRIPPIECE400", "여행 조각이 존재하지 않습니다"),
+    NOT_FOUND_TRIPPIECE(HttpStatus.NOT_FOUND, "TRIPPIECE404", "여행 조각이 존재하지 않습니다"),
     INVALID_TRIPPIECE_SORT_OPTION(HttpStatus.BAD_REQUEST, "TRIPPIECE401", "유효하지 않은 정렬 조건입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
@@ -21,7 +21,6 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_MAP(HttpStatus.NOT_FOUND, "MAP400", "해당 맵을 찾을 수 없습니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER400", "해당 유저를 찾을 수 없습니다."),
     NOT_FOUND_CITY(HttpStatus.NOT_FOUND, "CITY400", "해당 도시를 찾을 수 없습니다."),
-    NOT_FOUND_TRIPPIECE(HttpStatus.NOT_FOUND, "TRIPPIECE400", "여행 조각이 존재하지 않습니다"),
 
     // s3 관련 오류
     PICTURE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "PICTURE400", "이미지의 확장자가 잘못되었습니다."),
@@ -39,7 +38,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // 사용자 관련 오류
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "존재하지 않는 사용자입니다."),
     INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "PROFILE400", "잘못된 프로필 이미지 형식입니다."),
-    PROFILE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PROFILE500", "프로필 업데이트에 실패했습니다.");
+    PROFILE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PROFILE500", "프로필 업데이트에 실패했습니다."),
+
+    // 여행 조각 관련 오류
+    NOT_FOUND_TRIPPIECE(HttpStatus.NOT_FOUND, "TRIPPIECE400", "여행 조각이 존재하지 않습니다"),
+    INVALID_TRIPPIECE_SORT_OPTION(HttpStatus.BAD_REQUEST, "TRIPPIECE401", "유효하지 않은 정렬 조건입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // s3 관련 오류
     PICTURE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "PICTURE400", "이미지의 확장자가 잘못되었습니다."),
     VIDEO_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "VIDEO400", "동영상의 확장자가 잘못되었습니다."),
+    PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "UPLOAD413", "파일 크기가 허용 범위를 초과했습니다."),
 
     // 이모지 오류
     EMOJI_NUMBER_ERROR(HttpStatus.BAD_REQUEST, "EMOJI400", "이모지의 갯수는 4개이여야 합니다."),
@@ -32,7 +33,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 글자 수 오류
     TEXT_LENGTH_30_ERROR(HttpStatus.BAD_REQUEST, "TEXT400", "글자 수가 30자를 초과하였습니다."),
-    TEXT_LENGTH_100_ERROR(HttpStatus.BAD_REQUEST, "TEXT401", "글자 수가 100자를 초과하였습니다.");
+    TEXT_LENGTH_100_ERROR(HttpStatus.BAD_REQUEST, "TEXT401", "글자 수가 100자를 초과하였습니다."),
+
+    // 사용자 관련 오류
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "존재하지 않는 사용자입니다."),
+    INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "PROFILE400", "잘못된 프로필 이미지 형식입니다."),
+    PROFILE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PROFILE500", "프로필 업데이트에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_MAP(HttpStatus.NOT_FOUND, "MAP400", "해당 맵을 찾을 수 없습니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER400", "해당 유저를 찾을 수 없습니다."),
     NOT_FOUND_CITY(HttpStatus.NOT_FOUND, "CITY400", "해당 도시를 찾을 수 없습니다."),
+    NOT_FOUND_TRIPPIECE(HttpStatus.NOT_FOUND, "TRIPPIECE400", "여행 조각이 존재하지 않습니다"),
 
     // s3 관련 오류
     PICTURE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "PICTURE400", "이미지의 확장자가 잘못되었습니다."),

--- a/src/main/java/umc/TripPiece/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/umc/TripPiece/apiPayload/code/status/SuccessStatus.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum SuccessStatus {
-    _OK("200", "Operation successful");
+    _OK("200", "요청에 성공했습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/umc/TripPiece/apiPayload/exception/handler/BadRequestHandler.java
+++ b/src/main/java/umc/TripPiece/apiPayload/exception/handler/BadRequestHandler.java
@@ -1,0 +1,8 @@
+package umc.TripPiece.apiPayload.exception.handler;
+
+import umc.TripPiece.apiPayload.code.BaseErrorCode;
+import umc.TripPiece.apiPayload.exception.GeneralException;
+
+public class BadRequestHandler extends GeneralException {
+    public BadRequestHandler(BaseErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/umc/TripPiece/apiPayload/exception/handler/NotFoundHandler.java
+++ b/src/main/java/umc/TripPiece/apiPayload/exception/handler/NotFoundHandler.java
@@ -1,0 +1,8 @@
+package umc.TripPiece.apiPayload.exception.handler;
+
+import umc.TripPiece.apiPayload.code.BaseErrorCode;
+import umc.TripPiece.apiPayload.exception.GeneralException;
+
+public class NotFoundHandler extends GeneralException {
+    public NotFoundHandler(BaseErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/umc/TripPiece/apiPayload/exception/handler/UserHandler.java
+++ b/src/main/java/umc/TripPiece/apiPayload/exception/handler/UserHandler.java
@@ -1,0 +1,8 @@
+package umc.TripPiece.apiPayload.exception.handler;
+
+import umc.TripPiece.apiPayload.code.BaseErrorCode;
+import umc.TripPiece.apiPayload.exception.GeneralException;
+
+public class UserHandler extends GeneralException {
+    public UserHandler(BaseErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/umc/TripPiece/service/TripPieceService.java
+++ b/src/main/java/umc/TripPiece/service/TripPieceService.java
@@ -37,11 +37,16 @@ public class TripPieceService {
     private final JWTUtil jwtUtil;
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getTripPieceListLatest(String token) {
+    public List<TripPieceResponseDto.TripPieceListDto> getTripPieceList(String token, String sort) {
         Long userId = jwtUtil.getUserIdFromToken(token);
 
+        // 정렬 기준에 따라 데이터를 조회
+        List<TripPiece> tripPieces = "earliest".equalsIgnoreCase(sort)
+                ? tripPieceRepository.findByUserIdOrderByCreatedAtAsc(userId)
+                : tripPieceRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
-        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
         for (TripPiece tripPiece : tripPieces) {
             Travel travel = tripPiece.getTravel();
             City city = travel.getCity();
@@ -92,66 +97,15 @@ public class TripPieceService {
     }
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getTripPieceListEarliest(String token) {
+    public List<TripPieceResponseDto.TripPieceListDto> getMemoList(String token, String sort) {
         Long userId = jwtUtil.getUserIdFromToken(token);
 
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
-        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdOrderByCreatedAtAsc(userId);
-        for (TripPiece tripPiece : tripPieces) {
-            Travel travel = tripPiece.getTravel();
-            City city = travel.getCity();
-            Country country = city.getCountry();
-            Category category = tripPiece.getCategory();
-
-            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
-
-            if (category == Category.MEMO)
-            {
-                tripPieceListDto.setCategory(Category.MEMO);
-                tripPieceListDto.setMemo(tripPiece.getDescription());
-            }
-            else if (category == Category.EMOJI)
-            {
-                List<Emoji> emojis = tripPiece.getEmojis();
-
-                tripPieceListDto.setCategory(Category.MEMO);
-                tripPieceListDto.setMemo(emojis.get(0).getEmoji() + emojis.get(1).getEmoji() + emojis.get(2).getEmoji() + emojis.get(3).getEmoji());
-            }
-            else if (category == Category.PICTURE || category == Category.SELFIE)
-            {
-                // 여러개 사진이 있다면, 썸네일 랜덤
-                List<Picture> pictures = tripPiece.getPictures();
-                Random random = new Random();
-                int randomIndex = random.nextInt(pictures.size());
-
-                tripPieceListDto.setCategory(Category.PICTURE);
-                tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
-            }
-            else if (category == Category.VIDEO || category == Category.WHERE)
-            {
-                List<Video> videos = tripPiece.getVideos();
-                Video video = videos.get(0);
-
-                tripPieceListDto.setCategory(Category.VIDEO);
-                tripPieceListDto.setMediaUrl(video.getVideoUrl());
-            }
-
-            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
-            tripPieceListDto.setCountryName(country.getName());
-            tripPieceListDto.setCityName(city.getName());
-
-            tripPieceList.add(tripPieceListDto);
-        }
-
-        return tripPieceList;
-    }
-
-    @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getMemoListLatest(String token) {
-        Long userId = jwtUtil.getUserIdFromToken(token);
+        // 정렬 기준에 따라 데이터를 조회
+        List<TripPiece> tripPieces = "earliest".equalsIgnoreCase(sort)
+                ? tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.MEMO, Category.EMOJI)
+                : tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.MEMO, Category.EMOJI);
 
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
-        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.MEMO, Category.EMOJI);
 
         for (TripPiece tripPiece : tripPieces) {
             Travel travel = tripPiece.getTravel();
@@ -185,82 +139,16 @@ public class TripPieceService {
     }
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getMemoListEarliest(String token) {
+    public List<TripPieceResponseDto.TripPieceListDto> getPictureList(String token, String sort) {
         Long userId = jwtUtil.getUserIdFromToken(token);
 
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
-        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.MEMO, Category.EMOJI);
+        // 정렬 기준에 따라 데이터를 조회
+        List<TripPiece> tripPieces = "earliest".equalsIgnoreCase(sort)
+                ? tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.PICTURE, Category.SELFIE)
+                : tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.PICTURE, Category.SELFIE);
 
-        for (TripPiece tripPiece : tripPieces) {
-            Travel travel = tripPiece.getTravel();
-            City city = travel.getCity();
-            Country country = city.getCountry();
-            Category category = tripPiece.getCategory();
-
-            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
-
-            tripPieceListDto.setCategory(Category.MEMO);
-
-            if (category == Category.MEMO)
-            {
-                tripPieceListDto.setMemo(tripPiece.getDescription());
-            }
-            else if (category == Category.EMOJI)
-            {
-                List<Emoji> emojis = tripPiece.getEmojis();
-
-                tripPieceListDto.setMemo(emojis.get(0).getEmoji() + emojis.get(1).getEmoji() + emojis.get(2).getEmoji() + emojis.get(3).getEmoji());
-            }
-
-            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
-            tripPieceListDto.setCountryName(country.getName());
-            tripPieceListDto.setCityName(city.getName());
-
-            tripPieceList.add(tripPieceListDto);
-        }
-
-        return tripPieceList;
-    }
-
-    @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getPictureListLatest(String token) {
-        Long userId = jwtUtil.getUserIdFromToken(token);
 
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
-        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.PICTURE, Category.SELFIE);
-
-        for (TripPiece tripPiece : tripPieces) {
-            Travel travel = tripPiece.getTravel();
-            City city = travel.getCity();
-            Country country = city.getCountry();
-
-            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
-
-            // 여러개 사진이 있다면, 썸네일 랜덤
-            List<Picture> pictures = tripPiece.getPictures();
-            Random random = new Random();
-            int randomIndex = random.nextInt(pictures.size());
-
-            tripPieceListDto.setCategory(Category.PICTURE);
-            tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
-
-            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
-            tripPieceListDto.setCountryName(country.getName());
-            tripPieceListDto.setCityName(city.getName());
-
-            tripPieceList.add(tripPieceListDto);
-        }
-
-        return tripPieceList;
-    }
-
-
-    @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getPictureListEarliest(String token) {
-        Long userId = jwtUtil.getUserIdFromToken(token);
-
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
-        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.PICTURE, Category.SELFIE);
 
         for (TripPiece tripPiece : tripPieces) {
             Travel travel = tripPiece.getTravel();
@@ -288,41 +176,16 @@ public class TripPieceService {
     }
 
     @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getVideoListLatest(String token) {
+    public List<TripPieceResponseDto.TripPieceListDto> getVideoList(String token, String sort) {
         Long userId = jwtUtil.getUserIdFromToken(token);
 
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
-        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.VIDEO, Category.WHERE);
+        // 정렬 기준에 따라 데이터를 조회
+        List<TripPiece> tripPieces = "earliest".equalsIgnoreCase(sort)
+                ? tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.VIDEO, Category.WHERE)
+                : tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtDesc(userId, Category.VIDEO, Category.WHERE);
 
-        for (TripPiece tripPiece : tripPieces) {
-            Travel travel = tripPiece.getTravel();
-            City city = travel.getCity();
-            Country country = city.getCountry();
-
-            TripPieceResponseDto.TripPieceListDto tripPieceListDto = new TripPieceResponseDto.TripPieceListDto();
-
-            List<Video> videos = tripPiece.getVideos();
-            Video video = videos.get(0);
-
-            tripPieceListDto.setCategory(Category.VIDEO);
-            tripPieceListDto.setMediaUrl(video.getVideoUrl());
-
-            tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
-            tripPieceListDto.setCountryName(country.getName());
-            tripPieceListDto.setCityName(city.getName());
-
-            tripPieceList.add(tripPieceListDto);
-        }
-
-        return tripPieceList;
-    }
-
-    @Transactional
-    public List<TripPieceResponseDto.TripPieceListDto> getVideoListEarliest(String token) {
-        Long userId = jwtUtil.getUserIdFromToken(token);
 
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = new ArrayList<>();
-        List<TripPiece> tripPieces = tripPieceRepository.findByUserIdAndCategoryOrCategoryOrderByCreatedAtAsc(userId, Category.VIDEO, Category.WHERE);
 
         for (TripPiece tripPiece : tripPieces) {
             Travel travel = tripPiece.getTravel();

--- a/src/main/java/umc/TripPiece/service/TripPieceService.java
+++ b/src/main/java/umc/TripPiece/service/TripPieceService.java
@@ -13,7 +13,6 @@ import umc.TripPiece.domain.jwt.JWTUtil;
 import umc.TripPiece.repository.EmojiRepository;
 import umc.TripPiece.repository.PictureRepository;
 import umc.TripPiece.repository.TripPieceRepository;
-import umc.TripPiece.repository.UserRepository;
 import umc.TripPiece.repository.UuidRepository;
 import umc.TripPiece.repository.VideoRepository;
 import umc.TripPiece.web.dto.request.TripPieceRequestDto;
@@ -76,6 +75,7 @@ public class TripPieceService {
 
                 tripPieceListDto.setCategory(Category.PICTURE);
                 tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
+                tripPieceListDto.setMemo(tripPiece.getDescription());
             }
             else if (category == Category.VIDEO || category == Category.WHERE)
             {
@@ -84,6 +84,7 @@ public class TripPieceService {
 
                 tripPieceListDto.setCategory(Category.VIDEO);
                 tripPieceListDto.setMediaUrl(video.getVideoUrl());
+                tripPieceListDto.setMemo(tripPiece.getDescription());
             }
 
             tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
@@ -164,7 +165,7 @@ public class TripPieceService {
 
             tripPieceListDto.setCategory(Category.PICTURE);
             tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
-
+            tripPieceListDto.setMemo(tripPiece.getDescription());
             tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
             tripPieceListDto.setCountryName(country.getName());
             tripPieceListDto.setCityName(city.getName());
@@ -199,7 +200,7 @@ public class TripPieceService {
 
             tripPieceListDto.setCategory(Category.VIDEO);
             tripPieceListDto.setMediaUrl(video.getVideoUrl());
-
+            tripPieceListDto.setMemo(tripPiece.getDescription());
             tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
             tripPieceListDto.setCountryName(country.getName());
             tripPieceListDto.setCityName(city.getName());

--- a/src/main/java/umc/TripPiece/service/TripPieceService.java
+++ b/src/main/java/umc/TripPiece/service/TripPieceService.java
@@ -75,7 +75,6 @@ public class TripPieceService {
 
                 tripPieceListDto.setCategory(Category.PICTURE);
                 tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
-                tripPieceListDto.setMemo(tripPiece.getDescription());
             }
             else if (category == Category.VIDEO || category == Category.WHERE)
             {
@@ -84,7 +83,6 @@ public class TripPieceService {
 
                 tripPieceListDto.setCategory(Category.VIDEO);
                 tripPieceListDto.setMediaUrl(video.getVideoUrl());
-                tripPieceListDto.setMemo(tripPiece.getDescription());
             }
 
             tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
@@ -165,7 +163,6 @@ public class TripPieceService {
 
             tripPieceListDto.setCategory(Category.PICTURE);
             tripPieceListDto.setMediaUrl(pictures.get(randomIndex).getPictureUrl());
-            tripPieceListDto.setMemo(tripPiece.getDescription());
             tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
             tripPieceListDto.setCountryName(country.getName());
             tripPieceListDto.setCityName(city.getName());
@@ -200,7 +197,6 @@ public class TripPieceService {
 
             tripPieceListDto.setCategory(Category.VIDEO);
             tripPieceListDto.setMediaUrl(video.getVideoUrl());
-            tripPieceListDto.setMemo(tripPiece.getDescription());
             tripPieceListDto.setCreatedAt(tripPiece.getCreatedAt());
             tripPieceListDto.setCountryName(country.getName());
             tripPieceListDto.setCityName(city.getName());

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -21,79 +21,49 @@ public class TripPieceController {
     private final TripPieceService tripPieceService;
     private final TripPieceRepository tripPieceRepository;
 
-    @GetMapping("/mytrippieces/all/latest")
-    @Operation(summary = "지난 여행 조각(전체, 최신순) API", description = "유저의 여행조각(전체)을 최신순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListLatest(@RequestHeader("Authorization") String token){
+    @GetMapping("/mytrippieces/all")
+    @Operation(summary = "지난 여행 조각(전체) API", description = "유저의 여행조각(전체)을 정렬 기준에 따라 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceList(
+            @RequestHeader("Authorization") String token,
+            @RequestParam(value = "sort", defaultValue = "latest") String sort) {
+
         String tokenWithoutBearer = token.substring(7);
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListLatest(tokenWithoutBearer);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceList(tokenWithoutBearer, sort);
+
+        if (tripPieceList == null || tripPieceList.isEmpty()) {
+            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
+        }
+        return ApiResponse.onSuccess(tripPieceList);
+    }
+
+    @GetMapping("/mytrippieces/memo")
+    @Operation(summary = "지난 여행 조각(메모) API", description = "유저의 여행조각(메모, 이모지)을 정렬 기준에 따라 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListLatest(@RequestHeader("Authorization") String token, @RequestParam(value = "sort", defaultValue = "latest") String sort){
+        String tokenWithoutBearer = token.substring(7);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoList(tokenWithoutBearer, sort);
+
         if (tripPieceList == null || tripPieceList.isEmpty())
             return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
-    @GetMapping("/mytrippieces/all/earliest")
-    @Operation(summary = "지난 여행 조각(전체, 오래된순) API", description = "유저의 여행조각(전체)을 오래된순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getTripPieceListEarliest(@RequestHeader("Authorization") String token){
+    @GetMapping("/mytrippieces/picture")
+    @Operation(summary = "지난 여행 조각(사진) API", description = "유저의 여행조각(사진, 셀카)을 정렬 기준에 따라 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListLatest(@RequestHeader("Authorization") String token, @RequestParam(value = "sort", defaultValue = "latest") String sort) {
         String tokenWithoutBearer = token.substring(7);
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceListEarliest(tokenWithoutBearer);
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureList(tokenWithoutBearer, sort);
+
         if (tripPieceList == null || tripPieceList.isEmpty())
             return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
-    @GetMapping("/mytrippieces/memo/latest")
-    @Operation(summary = "지난 여행 조각(메모, 최신순) API", description = "유저의 여행조각(메모, 이모지)을 최신순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListLatest(@RequestHeader("Authorization") String token){
+    @GetMapping("/mytrippieces/video")
+    @Operation(summary = "지난 여행 조각(동영상) API", description = "유저의 여행조각(영상, '지금 어디에 있나요?')을 정렬 기준에 따라 반환")
+    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListLatest(@RequestHeader("Authorization") String token, @RequestParam(value = "sort", defaultValue = "latest") String sort){
         String tokenWithoutBearer = token.substring(7);
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoListLatest(tokenWithoutBearer);
-        if (tripPieceList == null || tripPieceList.isEmpty())
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
-        return ApiResponse.onSuccess(tripPieceList);
-    }
+        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoList(tokenWithoutBearer, sort);
 
-    @GetMapping("/mytrippieces/memo/earliest")
-    @Operation(summary = "지난 여행 조각(메모, 오래된순) API", description = "유저의 여행조각(메모, 이모지)을 오래된순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListEarliest(@RequestHeader("Authorization") String token){
-        String tokenWithoutBearer = token.substring(7);
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoListEarliest(tokenWithoutBearer);
-        return ApiResponse.onSuccess(tripPieceList);
-    }
-
-    @GetMapping("/mytrippieces/picture/latest")
-    @Operation(summary = "지난 여행 조각(사진, 최신순) API", description = "유저의 여행조각(사진, 셀카)을 최신순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListLatest(@RequestHeader("Authorization") String token){
-        String tokenWithoutBearer = token.substring(7);
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureListLatest(tokenWithoutBearer);
-        if (tripPieceList == null || tripPieceList.isEmpty())
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
-        return ApiResponse.onSuccess(tripPieceList);
-    }
-
-    @GetMapping("/mytrippieces/picture/earliest")
-    @Operation(summary = "지난 여행 조각(사진, 오래된순) API", description = "유저의 여행조각(사진, 셀카)을 오래된순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListEarliest(@RequestHeader("Authorization") String token){
-        String tokenWithoutBearer = token.substring(7);
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureListEarliest(tokenWithoutBearer);
-        if (tripPieceList == null || tripPieceList.isEmpty())
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
-        return ApiResponse.onSuccess(tripPieceList);
-    }
-
-    @GetMapping("/mytrippieces/video/latest")
-    @Operation(summary = "지난 여행 조각(동영상, 최신순) API", description = "유저의 여행조각(영상, '지금 어디에 있나요?')을 최신순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListLatest(@RequestHeader("Authorization") String token){
-        String tokenWithoutBearer = token.substring(7);
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoListLatest(tokenWithoutBearer);
-        if (tripPieceList == null || tripPieceList.isEmpty())
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
-        return ApiResponse.onSuccess(tripPieceList);
-    }
-
-    @GetMapping("/mytrippieces/video/earliest")
-    @Operation(summary = "지난 여행 조각(동영상, 오래된순) API", description = "유저의 여행조각(영상, '지금 어디에 있나요?')을 오래된순으로 반환")
-    public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListEarliest(@RequestHeader("Authorization") String token){
-        String tokenWithoutBearer = token.substring(7);
-        List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoListEarliest(tokenWithoutBearer);
         if (tripPieceList == null || tripPieceList.isEmpty())
             return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
         return ApiResponse.onSuccess(tripPieceList);

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.TripPiece.apiPayload.ApiResponse;
+import umc.TripPiece.apiPayload.code.status.ErrorStatus;
+import umc.TripPiece.apiPayload.exception.handler.NotFoundHandler;
 import umc.TripPiece.repository.TripPieceRepository;
 import umc.TripPiece.service.TripPieceService;
 import umc.TripPiece.web.dto.request.TripPieceRequestDto;
@@ -31,7 +33,7 @@ public class TripPieceController {
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceList(tokenWithoutBearer, sort);
 
         if (tripPieceList == null || tripPieceList.isEmpty()) {
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
+            throw new NotFoundHandler(ErrorStatus.NOT_FOUND_TRIPPIECE);
         }
         return ApiResponse.onSuccess(tripPieceList);
     }
@@ -43,7 +45,7 @@ public class TripPieceController {
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoList(tokenWithoutBearer, sort);
 
         if (tripPieceList == null || tripPieceList.isEmpty())
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
+            throw new NotFoundHandler(ErrorStatus.NOT_FOUND_TRIPPIECE);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
@@ -54,7 +56,7 @@ public class TripPieceController {
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureList(tokenWithoutBearer, sort);
 
         if (tripPieceList == null || tripPieceList.isEmpty())
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
+            throw new NotFoundHandler(ErrorStatus.NOT_FOUND_TRIPPIECE);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
@@ -65,7 +67,7 @@ public class TripPieceController {
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoList(tokenWithoutBearer, sort);
 
         if (tripPieceList == null || tripPieceList.isEmpty())
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
+            throw new NotFoundHandler(ErrorStatus.NOT_FOUND_TRIPPIECE);
         return ApiResponse.onSuccess(tripPieceList);
     }
 
@@ -74,7 +76,7 @@ public class TripPieceController {
     public ApiResponse<TripPieceResponseDto.getTripPieceDto> getTripPiece(@PathVariable("tripPieceId") Long tripPieceId){
         TripPieceResponseDto.getTripPieceDto response = tripPieceService.getTripPiece(tripPieceId);
         if (response == null)
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
+            throw new NotFoundHandler(ErrorStatus.NOT_FOUND_TRIPPIECE);
         return ApiResponse.onSuccess(response);
     }
 
@@ -82,7 +84,7 @@ public class TripPieceController {
     @Operation(summary = "여행 조각 삭제 API", description = "tripPieceId를 입력 받아 해당 여행 조각을 삭제")
     public ApiResponse<Object> deleteTripPiece(@PathVariable("tripPieceId") Long tripPieceId){
         if (!tripPieceRepository.existsById(tripPieceId))
-            return ApiResponse.onFailure("400", "여행 조각이 존재하지 않습니다.", null);
+            throw new NotFoundHandler(ErrorStatus.NOT_FOUND_TRIPPIECE);
         else {
             tripPieceService.delete(tripPieceId);
             return ApiResponse.onSuccess(null);

--- a/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TripPieceController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.TripPiece.apiPayload.ApiResponse;
 import umc.TripPiece.apiPayload.code.status.ErrorStatus;
+import umc.TripPiece.apiPayload.exception.handler.BadRequestHandler;
 import umc.TripPiece.apiPayload.exception.handler.NotFoundHandler;
 import umc.TripPiece.repository.TripPieceRepository;
 import umc.TripPiece.service.TripPieceService;
@@ -29,6 +30,10 @@ public class TripPieceController {
             @RequestHeader("Authorization") String token,
             @RequestParam(value = "sort", defaultValue = "latest") String sort) {
 
+        if (!"latest".equals(sort) && !"earliest".equals(sort)) {
+            throw new BadRequestHandler(ErrorStatus.INVALID_TRIPPIECE_SORT_OPTION);
+        }
+
         String tokenWithoutBearer = token.substring(7);
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getTripPieceList(tokenWithoutBearer, sort);
 
@@ -41,6 +46,10 @@ public class TripPieceController {
     @GetMapping("/mytrippieces/memo")
     @Operation(summary = "지난 여행 조각(메모) API", description = "유저의 여행조각(메모, 이모지)을 정렬 기준에 따라 반환")
     public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getMemoListLatest(@RequestHeader("Authorization") String token, @RequestParam(value = "sort", defaultValue = "latest") String sort){
+        if (!"latest".equals(sort) && !"earliest".equals(sort)) {
+            throw new BadRequestHandler(ErrorStatus.INVALID_TRIPPIECE_SORT_OPTION);
+        }
+
         String tokenWithoutBearer = token.substring(7);
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getMemoList(tokenWithoutBearer, sort);
 
@@ -52,6 +61,10 @@ public class TripPieceController {
     @GetMapping("/mytrippieces/picture")
     @Operation(summary = "지난 여행 조각(사진) API", description = "유저의 여행조각(사진, 셀카)을 정렬 기준에 따라 반환")
     public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getPictureListLatest(@RequestHeader("Authorization") String token, @RequestParam(value = "sort", defaultValue = "latest") String sort) {
+        if (!"latest".equals(sort) && !"earliest".equals(sort)) {
+            throw new BadRequestHandler(ErrorStatus.INVALID_TRIPPIECE_SORT_OPTION);
+        }
+
         String tokenWithoutBearer = token.substring(7);
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getPictureList(tokenWithoutBearer, sort);
 
@@ -63,6 +76,10 @@ public class TripPieceController {
     @GetMapping("/mytrippieces/video")
     @Operation(summary = "지난 여행 조각(동영상) API", description = "유저의 여행조각(영상, '지금 어디에 있나요?')을 정렬 기준에 따라 반환")
     public ApiResponse<List<TripPieceResponseDto.TripPieceListDto>> getVideoListLatest(@RequestHeader("Authorization") String token, @RequestParam(value = "sort", defaultValue = "latest") String sort){
+        if (!"latest".equals(sort) && !"earliest".equals(sort)) {
+            throw new BadRequestHandler(ErrorStatus.INVALID_TRIPPIECE_SORT_OPTION);
+        }
+
         String tokenWithoutBearer = token.substring(7);
         List<TripPieceResponseDto.TripPieceListDto> tripPieceList = tripPieceService.getVideoList(tokenWithoutBearer, sort);
 

--- a/src/main/java/umc/TripPiece/web/controller/UserController.java
+++ b/src/main/java/umc/TripPiece/web/controller/UserController.java
@@ -12,6 +12,9 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import umc.TripPiece.apiPayload.code.status.ErrorStatus;
+import umc.TripPiece.apiPayload.exception.GeneralException;
+import umc.TripPiece.apiPayload.exception.handler.UserHandler;
 import umc.TripPiece.converter.UserConverter;
 import umc.TripPiece.domain.User;
 import umc.TripPiece.domain.jwt.JWTUtil;
@@ -118,13 +121,14 @@ public class UserController {
     @Operation(summary = "프로필 수정하기 API",
             description = "프로필 수정하기")
     public ApiResponse<UserResponseDto.UpdateResultDto> update(@RequestPart("info") @Valid UserRequestDto.UpdateDto request, @RequestHeader("Authorization") String token, @RequestPart(value = "profileImg", required = false) MultipartFile profileImg) {
-        String tokenWithoutBearer = token.substring(7);
-        User user = userService.update(request, tokenWithoutBearer, profileImg);
-
-        if (user != null) {
+        try {
+            String tokenWithoutBearer = token.substring(7);
+            User user = userService.update(request, tokenWithoutBearer, profileImg);
             return ApiResponse.onSuccess(UserConverter.toUpdateResultDto(user));
-        } else {
-            return ApiResponse.onFailure("400", "프로필 수정에 실패했습니다.", null);
+        } catch (GeneralException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new UserHandler(ErrorStatus.PROFILE_UPDATE_FAILED);
         }
     }
 

--- a/src/main/java/umc/TripPiece/web/controller/UserController.java
+++ b/src/main/java/umc/TripPiece/web/controller/UserController.java
@@ -114,7 +114,7 @@ public class UserController {
         }
     }
 
-    @PostMapping(value = "/update", consumes = "multipart/form-data")
+    @PatchMapping(value = "/update", consumes = "multipart/form-data")
     @Operation(summary = "프로필 수정하기 API",
             description = "프로필 수정하기")
     public ApiResponse<UserResponseDto.UpdateResultDto> update(@RequestPart("info") @Valid UserRequestDto.UpdateDto request, @RequestHeader("Authorization") String token, @RequestPart(value = "profileImg", required = false) MultipartFile profileImg) {


### PR DESCRIPTION
## 연관 이슈

close #85

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
여행기 조각 정렬 및 프로필 수정 API 리팩토링
<br/>

## ✅ 작업 내용

- [x] 프로필 수정 patch로 변경
- [x] 프로필 수정 응답값 ErrorStatus 사용 리팩토링
- [x] 여행 조각 정렬 파라미터 활용해 리팩토링
- [x] 여행 조각 조회 응답값 ErrorStatus 사용 리팩토링

<br/>

![화면 캡처 2024-11-30 154321](https://github.com/user-attachments/assets/02e4d29d-9843-48b0-b767-a4075e7fd86c)

![화면 캡처 2024-12-01 041107](https://github.com/user-attachments/assets/8a85192d-e376-4b7a-b849-ac47e55f4f42)

![화면 캡처 2024-12-01 041151](https://github.com/user-attachments/assets/bf65634f-81e8-4123-b9d8-b479cc6e6cd0)

![화면 캡처 2024-12-01 042020](https://github.com/user-attachments/assets/30bb3cf5-b593-4c35-bd87-ea75083ca9dc)
![화면 캡처 2024-12-01 034905](https://github.com/user-attachments/assets/ef4142d1-baf7-4b30-9765-295023ffb4ff)


### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 리뷰 요청사항이 있습니다!
- 1) `ErrorStatus`를 작성하는 기준이 어떻게 되는지 궁금합니다. 지금은 `TEXT_LENGTH`, `NOT_FOUND` 이렇게 기능, 에러 원인 단위로 에러상태가 설정되어있는데 그렇다보니 조금 헷갈리는 부분이 있어서요! 예를 들어 글자 수가 필드에 따라서 요청 조건이 많이 다를텐데 이걸 TEXT 에러로 관리할 수 있을지 의문이 들었습니다. 또한, handler를 우선 NotFound랑 BadRequest로 나누었는데, 이걸 그냥 각각 TripPiece, Map, ... 이렇게 별도로 정의해야하는 것인지도 궁금했습니다! (사실 아무거나 import 해도 다 동작해서 핸들러에서 어떤 처리를 하는 것인지는 아직 모르겠어요)
- 2) 다음으로, 프로필도 그렇고 여행 조각에서도 그렇고 이미지를 업로드할 때 413 에러 (파일 사이즈 관련) 에러가 나오고 있어서 업로드 가능한 파일 사이즈 알려주시면 `PAYLOAD_TOO_LARGE` 에러 처리 해둘게요!
- 3) 마지막으로, 여행 조각 조회할 때 PICTURE이나 VIDEO는 아래처럼 memo에 null 값이 나오더라구요. 단일 조각 조회 외에는 메모를 확인할 수가 없길래 뭔가 빠졌다고 생각했습니다.(그래서 memo가 무조건 반환되도록 수정했는데 다시 생각해보니 없는 게 맞아 다시 원래대로 돌려두었어요) 여기서 생각이 든 게 굳이 null 값인 거를 응답값으로 보낼 필요가 있나 싶었어요! MEMO 타입은 memo만 나오고 mediaUrl은 안 나오고, PICTURE나 VEDIO는 memo는 안 나오고 mediaUrl만 나오고 있어서.. 이것들을 content라는 필드명으로 해서 MEMO 타입이면 memo를, PICTURE나 VEDIO는 mediaUrl을 담아 보내는 것은 어떨까요? 어차피 category가 있기 때문에 프론트에서 구분할 수 있을 거 같습니다!

![화면 캡처 2024-12-01 040808](https://github.com/user-attachments/assets/eaa46a7a-e8ee-485a-8c65-f847f604b0fd)


확인하시고 답변 주시면 감사드리겠습니다!
