### PR TITLE
[feature] 여행기 퍼즐 사진 수정

### DIFF
--- a/src/main/java/umc/TripPiece/converter/TravelConverter.java
+++ b/src/main/java/umc/TripPiece/converter/TravelConverter.java
@@ -118,5 +118,12 @@ public class TravelConverter {
                 .build();
     }
 
+    public static TravelResponseDto.UpdatablePictureDto toUpdatablePictureDto(Picture picture) {
+        return TravelResponseDto.UpdatablePictureDto.builder()
+                .id(picture.getId())
+                .pictureUrl(picture.getPictureUrl())
+                .travel_thumbnail(picture.getTravel_thumbnail())
+                .build();
+    }
 
 }

--- a/src/main/java/umc/TripPiece/converter/TravelConverter.java
+++ b/src/main/java/umc/TripPiece/converter/TravelConverter.java
@@ -123,6 +123,7 @@ public class TravelConverter {
                 .id(picture.getId())
                 .pictureUrl(picture.getPictureUrl())
                 .travel_thumbnail(picture.getTravel_thumbnail())
+                .thumbnail_index(picture.getThumbnail_index())
                 .build();
     }
 

--- a/src/main/java/umc/TripPiece/domain/Picture.java
+++ b/src/main/java/umc/TripPiece/domain/Picture.java
@@ -28,6 +28,11 @@ public class Picture extends BaseEntity {
     @Setter
     private Boolean travel_thumbnail;
 
+    @Column
+    @ColumnDefault("0")
+    @Setter
+    private Integer thumbnail_index;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trip_piece_id")
     private TripPiece tripPiece;

--- a/src/main/java/umc/TripPiece/domain/Picture.java
+++ b/src/main/java/umc/TripPiece/domain/Picture.java
@@ -2,11 +2,16 @@ package umc.TripPiece.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.TripPiece.domain.common.BaseEntity;
 
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Picture extends BaseEntity {
@@ -17,6 +22,11 @@ public class Picture extends BaseEntity {
 
     @Column(unique = true)
     private String pictureUrl;
+
+    @Column
+    @ColumnDefault("false")
+    @Setter
+    private Boolean travel_thumbnail;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trip_piece_id")

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -295,11 +295,20 @@ public class TravelService {
         return TravelConverter.toOngoingTravelResultDto(travel, nickname, profileImg, countryName, dayCount);
     }
 
+    @Transactional
+    public List<TravelResponseDto.UpdatablePictureDto> getPictureResponses(Long travelId) {
+        Travel travel = travelRepository.findById(travelId).orElseThrow(() -> new IllegalArgumentException("travel not found"));
+
+        return getPictures(travel).stream()
+                .map(TravelConverter::toUpdatablePictureDto)
+                .toList();
+    }
+
     private void setPictureThumbnail(Travel travel) {
         List<Picture> pictures = getPictures(travel);
 
         // 여행 종료 시 썸네일 랜덤 지정
-        while (!isThumbnailAvailable(travel)) {
+        while (isThumbnailAvailable(travel)) {
             int randomIndex = (int) (Math.random() * pictures.size());
             Picture picture = pictures.get(randomIndex);
             picture.setTravel_thumbnail(true);

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -304,6 +304,16 @@ public class TravelService {
                 .toList();
     }
 
+    @Transactional
+    public List<TravelResponseDto.UpdatablePictureDto> getThumbnailPictures(Long travelId) {
+        Travel travel = travelRepository.findById(travelId).orElseThrow(() -> new IllegalArgumentException("travel not found"));
+
+        return getPictures(travel).stream()
+                .filter(picture -> picture.getTravel_thumbnail().equals(true))
+                .map(TravelConverter::toUpdatablePictureDto)
+                .toList();
+    }
+
     private void setPictureThumbnail(Travel travel) {
         List<Picture> pictures = getPictures(travel);
 

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -316,9 +316,20 @@ public class TravelService {
                 .toList();
     }
 
+    @Transactional
+    public TravelResponseDto.UpdatablePictureDto removeThumbnail(Long pictureId) {
+        Picture picture = pictureRepository.findById(pictureId).orElseThrow(() -> new IllegalArgumentException("picture not found"));
+
+        // index가 0이면 thumbnail 해제
+        picture.setThumbnail_index(0);
+        picture.setTravel_thumbnail(false);
+        return TravelConverter.toUpdatablePictureDto(picture);
+    }
+
     private void setPictureThumbnail(Travel travel) {
         List<Picture> pictures = getPictures(travel);
         int thumbnailIndex = 1;
+
         // 여행 종료 시 썸네일 랜덤 지정
         while (isThumbnailAvailable(travel)) {
             int randomIndex = (int) (Math.random() * pictures.size());
@@ -351,5 +362,4 @@ public class TravelService {
 
         return pictures;
     }
-
 }

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -362,6 +362,9 @@ public class TravelService {
             picture.setThumbnail_index(thumbnailIndex);
             pictures.remove(picture);
             thumbnailIndex++;
+
+            // 사진이 9장보다 적을 때, 다 설정이 되면 메서드 종료
+            if (pictures.isEmpty()) return;
         }
     }
 

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -308,21 +308,25 @@ public class TravelService {
     public List<TravelResponseDto.UpdatablePictureDto> getThumbnailPictures(Long travelId) {
         Travel travel = travelRepository.findById(travelId).orElseThrow(() -> new IllegalArgumentException("travel not found"));
 
+        // index 순으로 List 반환
         return getPictures(travel).stream()
                 .filter(picture -> picture.getTravel_thumbnail().equals(true))
+                .sorted(Comparator.comparingInt(Picture::getThumbnail_index))
                 .map(TravelConverter::toUpdatablePictureDto)
                 .toList();
     }
 
     private void setPictureThumbnail(Travel travel) {
         List<Picture> pictures = getPictures(travel);
-
+        int thumbnailIndex = 1;
         // 여행 종료 시 썸네일 랜덤 지정
         while (isThumbnailAvailable(travel)) {
             int randomIndex = (int) (Math.random() * pictures.size());
             Picture picture = pictures.get(randomIndex);
             picture.setTravel_thumbnail(true);
+            picture.setThumbnail_index(thumbnailIndex);
             pictures.remove(picture);
+            thumbnailIndex++;
         }
     }
 

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -320,7 +320,10 @@ public class TravelService {
     public TravelResponseDto.UpdatablePictureDto removeThumbnail(Long pictureId) {
         Picture picture = pictureRepository.findById(pictureId).orElseThrow(() -> new IllegalArgumentException("picture not found"));
 
-        // index가 0이면 thumbnail 해제
+        if (picture.getTravel_thumbnail().equals(false) && picture.getThumbnail_index() == 0)
+            throw new IllegalArgumentException("이미 썸네일이 해제되어있는 사진입니다.");
+
+        // index를 0으로 만들어 thumbnail 해제
         picture.setThumbnail_index(0);
         picture.setTravel_thumbnail(false);
         return TravelConverter.toUpdatablePictureDto(picture);

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -202,4 +202,11 @@ public class TravelController {
         return ApiResponse.onSuccess(response);
     }
 
+    @GetMapping("/mytravels/thumbnail/{travelId}")
+    @Operation(summary = "특정 여행기의 썸네일 사진들을 불러오는 API", description = "9개의 사진을 불러온다")
+    public ApiResponse<List<TravelResponseDto.UpdatablePictureDto>> getThumbnailPictures(@PathVariable("travelId") Long travelId) {
+        List<TravelResponseDto.UpdatablePictureDto> response = travelService.getThumbnailPictures(travelId);
+        return ApiResponse.onSuccess(response);
+    }
+
 }

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -209,17 +209,11 @@ public class TravelController {
         return ApiResponse.onSuccess(response);
     }
 
-    @PostMapping("/mytravels/thumbnail/remove/{pictureId}")
-    @Operation(summary = "특정 여행기에서 썸네일로 설정된 사진을 해제하는 API", description = "썸네일에서 해제한다")
-    public ApiResponse<TravelResponseDto.UpdatablePictureDto> removeThumbnailPicture(@PathVariable("pictureId") Long pictureId) {
-        TravelResponseDto.UpdatablePictureDto response = travelService.removeThumbnail(pictureId);
+    @PostMapping("/mytravels/thumbnail/update/{travelId}")
+    @Operation(summary = "특정 여행기에서 썸네일을 편집하는 API", description = "리스트의 크기는 9이며, 썸네일에 표시될 사진의 id가 index 순서대로 정렬되어 있다. id값에 -1이 입력되면 썸네일을 제거한다")
+    public ApiResponse<List<TravelResponseDto.UpdatablePictureDto>> updateThumbnailPictures(@PathVariable("travelId") Long travelId, @RequestParam(name = "pictureIdList") List<Long> pictureIdList) {
+        List<TravelResponseDto.UpdatablePictureDto> response = travelService.updateThumbnail(travelId, pictureIdList);
         return ApiResponse.onSuccess(response);
     }
 
-    @PostMapping("/mytravels/thumbnail/set/{pictureId}")
-    @Operation(summary = "특정 여행기에서 특정 사진을 썸네일로 설정하는 API", description = "index(1~9)를 입력받아 해당 자리에 썸네일 설정")
-    public ApiResponse<TravelResponseDto.UpdatablePictureDto> setThumbnailPicture(@PathVariable("pictureId") Long pictureId, Integer index) {
-        TravelResponseDto.UpdatablePictureDto response = travelService.setPictureThumbnail(pictureId, index);
-        return ApiResponse.onSuccess(response);
-    }
 }

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -215,4 +215,11 @@ public class TravelController {
         TravelResponseDto.UpdatablePictureDto response = travelService.removeThumbnail(pictureId);
         return ApiResponse.onSuccess(response);
     }
+
+    @PostMapping("/mytravels/thumbnail/set/{pictureId}")
+    @Operation(summary = "특정 여행기에서 특정 사진을 썸네일로 설정하는 API", description = "index(1~9)를 입력받아 해당 자리에 썸네일 설정")
+    public ApiResponse<TravelResponseDto.UpdatablePictureDto> setThumbnailPicture(@PathVariable("pictureId") Long pictureId, Integer index) {
+        TravelResponseDto.UpdatablePictureDto response = travelService.setPictureThumbnail(pictureId, index);
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -195,5 +195,11 @@ public class TravelController {
         return ApiResponse.onSuccess(travel);
     }
 
+    @GetMapping("/mytravels/update/{travelId}")
+    @Operation(summary = "특정 여행기의 사진들을 모두 불러오는 API", description = "여행기 수정 시에 활용")
+    public ApiResponse<List<TravelResponseDto.UpdatablePictureDto>> getUpdatablePictures(@PathVariable("travelId") Long travelId) {
+        List<TravelResponseDto.UpdatablePictureDto> response = travelService.getPictureResponses(travelId);
+        return ApiResponse.onSuccess(response);
+    }
 
 }

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -209,4 +209,10 @@ public class TravelController {
         return ApiResponse.onSuccess(response);
     }
 
+    @PostMapping("/mytravels/thumbnail/remove/{pictureId}")
+    @Operation(summary = "특정 여행기에서 썸네일로 설정된 사진을 해제하는 API", description = "썸네일에서 해제한다")
+    public ApiResponse<TravelResponseDto.UpdatablePictureDto> removeThumbnailPicture(@PathVariable("pictureId") Long pictureId) {
+        TravelResponseDto.UpdatablePictureDto response = travelService.removeThumbnail(pictureId);
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
@@ -105,11 +105,4 @@ public class TravelResponseDto {
         Integer videoNum;
     }
 
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class getPictureTripPieceDto {
-
-    }
 }

--- a/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
@@ -105,4 +105,11 @@ public class TravelResponseDto {
         Integer videoNum;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getPictureTripPieceDto {
+
+    }
 }

--- a/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
@@ -105,4 +105,13 @@ public class TravelResponseDto {
         Integer videoNum;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdatablePictureDto {
+        Long id;
+        String pictureUrl;
+        Boolean travel_thumbnail;
+    }
 }

--- a/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
@@ -113,5 +113,6 @@ public class TravelResponseDto {
         Long id;
         String pictureUrl;
         Boolean travel_thumbnail;
+        Integer thumbnail_index;
     }
 }

--- a/src/main/java/umc/TripPiece/web/dto/response/TripPieceResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TripPieceResponseDto.java
@@ -10,20 +10,6 @@ public class TripPieceResponseDto {
 
     @Builder
     @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class TripPieceListDto {
-        Category category;
-        LocalDateTime createdAt;
-        String countryName;
-        String cityName;
-        String memo;
-        String mediaUrl;
-    }
-
-    @Builder
-    @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class getTripPieceDto {

--- a/src/main/java/umc/TripPiece/web/dto/response/TripPieceResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TripPieceResponseDto.java
@@ -10,6 +10,20 @@ public class TripPieceResponseDto {
 
     @Builder
     @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TripPieceListDto {
+        Category category;
+        LocalDateTime createdAt;
+        String countryName;
+        String cityName;
+        String memo;
+        String mediaUrl;
+    }
+
+    @Builder
+    @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class getTripPieceDto {


### PR DESCRIPTION
## 개요

- 여행기 퍼즐 사진 수정
- Picture 객체에 필드 추가
  - travel_thumbnail: 썸네일로 설정되어있는지 (true/false)
  - thumbnail_index: 썸네일에 몇 번째 index인지 (1~9)
- 여행 종료 시 해당 여행기의 사진 중에서 썸네일 랜덤 지정
  - 랜덤으로 9장 뽑아서 썸네일 지정

<br/>

## ✅ 작업 내용

- [x] 여행기에 설정된 썸네일 불러오기
  - 썸네일로 설정되어 있으므로 모두 travel_thumbnail = true 값을 가짐
  - thumbnail_index 값은 1~9 의 값을 가짐
<img width="141" alt="image" src="https://github.com/user-attachments/assets/82bf0417-c6d9-479f-bafd-a9a58243f860" />
<img width="711" alt="image" src="https://github.com/user-attachments/assets/ca5d7263-716b-4f60-84c9-1bf3e3816d8c" />

-----
- [x] 여행기의 사진들 모두 불러오기 
  - 보라색 테두리가 썸네일로 설정되어있는 사진들이고, travel_thumbnail = true 값을 가짐
  - 썸네일로 설정되어 있는 사진들은 모두 thumbnail_index가 1~9의 값을 가짐
  - 썸네일이 아니라면 thumbnail_index = 0임
<img width="136" alt="image" src="https://github.com/user-attachments/assets/d1716380-35d5-46bf-ac3c-1a29811bda83" />
<img width="723" alt="image" src="https://github.com/user-attachments/assets/d9335c88-1aca-410f-ae47-42b7927dd1bb" />

-----
### 수정 사항
- [x] 썸네일 추가 및 삭제 기능 통합 (편집)
<img width="720" alt="image" src="https://github.com/user-attachments/assets/1262667e-290c-4673-a8fd-3ee6f651e921" />

  - 리스트의 크기가 9가 아닐 때, 해당 여행기에 입력한 id의 사진이 존재하지 않을 때 예외 처리
  - id의 값이 -1이라면 해당 index의 썸네일은 비어있는 상태로 수정됨

<img width="653" alt="image" src="https://github.com/user-attachments/assets/3bf748a8-61e1-4979-bf31-8f7fb95733aa" />
<img width="643" alt="image" src="https://github.com/user-attachments/assets/57e67ac7-fe17-4c90-98c5-3e87dcd34761" />
  
  - 4번째, 6번째는 response 값으로 나오지 않는 것을 볼 수 있습니다.

### 📝 논의사항

이 방법이 제일 간단해보이는 방법같은데, 문제가 있다면 수정하겠습니다.
