### PR TITLE
[refactor] 탐색 API ErrorStatus 설정

### DIFF
--- a/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_MAP(HttpStatus.NOT_FOUND, "MAP404", "해당 맵을 찾을 수 없습니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER404", "해당 유저를 찾을 수 없습니다."),
     NOT_FOUND_CITY(HttpStatus.NOT_FOUND, "CITY404", "해당 도시를 찾을 수 없습니다."),
+    NOT_FOUND_TRAVEL(HttpStatus.NOT_FOUND, "TRAVEL404", "해당 여행기를 찾을 수 없습니다."),
 
     // s3 관련 오류
     PICTURE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "PICTURE400", "이미지의 확장자가 잘못되었습니다."),
@@ -42,7 +43,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 여행 조각 관련 오류
     NOT_FOUND_TRIPPIECE(HttpStatus.NOT_FOUND, "TRIPPIECE404", "여행 조각이 존재하지 않습니다"),
-    INVALID_TRIPPIECE_SORT_OPTION(HttpStatus.BAD_REQUEST, "TRIPPIECE401", "유효하지 않은 정렬 조건입니다.");
+    INVALID_TRIPPIECE_SORT_OPTION(HttpStatus.BAD_REQUEST, "TRIPPIECE401", "유효하지 않은 정렬 조건입니다."),
+
+    // 여행기 관련 오류
+    INVALID_TRAVEL_PARARM(HttpStatus.BAD_REQUEST, "TRAVEL400", "유요하지 않은 파라미터입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/TripPiece/service/ExploreService.java
+++ b/src/main/java/umc/TripPiece/service/ExploreService.java
@@ -55,7 +55,7 @@ public class ExploreService {
     @Transactional
     public List<ExploreResponseDto.PopularCitiesDto> getCitiesByTravelCount() {
        List<City> cities = cityRepository.findAllByOrderByLogCountDesc();
-       return cities.stream().map(ExploreConverter::toPopularCitiesDto).toList();
+       return cities.stream().limit(8).map(ExploreConverter::toPopularCitiesDto).toList();
     }
 
 

--- a/src/main/java/umc/TripPiece/service/ExploreService.java
+++ b/src/main/java/umc/TripPiece/service/ExploreService.java
@@ -44,10 +44,8 @@ public class ExploreService {
         List<Travel> travels;
         if(sort.equals("latest")) {
             travels = travelRepository.findByCityIdInAndTravelOpenTrueOrderByCreatedAtDesc(new ArrayList<>(cityIds));
-        } else if (sort.equals("oldest")) {
-            travels = travelRepository.findByCityIdInAndTravelOpenTrueOrderByCreatedAtAsc(new ArrayList<>(cityIds));
         } else {
-            throw new BadRequestHandler(ErrorStatus.INVALID_TRAVEL_PARARM);
+            travels = travelRepository.findByCityIdInAndTravelOpenTrueOrderByCreatedAtAsc(new ArrayList<>(cityIds));
         }
         return travels.stream().distinct().map(ExploreConverter::toExploreListDto).toList();
     }

--- a/src/main/java/umc/TripPiece/service/ExploreService.java
+++ b/src/main/java/umc/TripPiece/service/ExploreService.java
@@ -3,6 +3,8 @@ package umc.TripPiece.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.TripPiece.apiPayload.code.status.ErrorStatus;
+import umc.TripPiece.apiPayload.exception.handler.BadRequestHandler;
 import umc.TripPiece.converter.ExploreConverter;
 import umc.TripPiece.converter.TravelConverter;
 import umc.TripPiece.domain.City;
@@ -45,7 +47,7 @@ public class ExploreService {
         } else if (sort.equals("oldest")) {
             travels = travelRepository.findByCityIdInAndTravelOpenTrueOrderByCreatedAtAsc(new ArrayList<>(cityIds));
         } else {
-            throw new IllegalArgumentException("파라미터 값이 잘못 되었습니다.");
+            throw new BadRequestHandler(ErrorStatus.INVALID_TRAVEL_PARARM);
         }
         return travels.stream().distinct().map(ExploreConverter::toExploreListDto).toList();
     }

--- a/src/main/java/umc/TripPiece/web/controller/ExploreController.java
+++ b/src/main/java/umc/TripPiece/web/controller/ExploreController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.TripPiece.apiPayload.ApiResponse;
 import umc.TripPiece.apiPayload.code.status.ErrorStatus;
+import umc.TripPiece.apiPayload.exception.handler.BadRequestHandler;
 import umc.TripPiece.apiPayload.exception.handler.NotFoundHandler;
 import umc.TripPiece.service.ExploreService;
 import umc.TripPiece.web.dto.response.ExploreResponseDto;
@@ -25,7 +26,12 @@ public class ExploreController {
     @GetMapping("/search")
     @Operation(summary = "도시, 국가 검색 API", description = "도시, 국가 검색")
     public ApiResponse<List<ExploreResponseDto.ExploreListDto>> getSearchedTravelList(@RequestParam String query, @RequestParam(defaultValue = "latest") String sort) {
-     List<ExploreResponseDto.ExploreListDto> travels = exploreService.searchTravels(query, sort);
+        List<ExploreResponseDto.ExploreListDto> travels;
+        if ("latest".equals(sort) || "oldest".equals(sort)) {
+            travels = exploreService.searchTravels(query, sort);
+        } else {
+            throw new BadRequestHandler(ErrorStatus.INVALID_TRAVEL_PARARM);
+        }
      if(travels.isEmpty()){
          throw new NotFoundHandler(ErrorStatus.NOT_FOUND_TRAVEL);
      }

--- a/src/main/java/umc/TripPiece/web/controller/ExploreController.java
+++ b/src/main/java/umc/TripPiece/web/controller/ExploreController.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.TripPiece.apiPayload.ApiResponse;
+import umc.TripPiece.apiPayload.code.status.ErrorStatus;
+import umc.TripPiece.apiPayload.exception.handler.NotFoundHandler;
 import umc.TripPiece.service.ExploreService;
 import umc.TripPiece.web.dto.response.ExploreResponseDto;
 import umc.TripPiece.web.dto.response.TravelResponseDto;
@@ -25,7 +27,7 @@ public class ExploreController {
     public ApiResponse<List<ExploreResponseDto.ExploreListDto>> getSearchedTravelList(@RequestParam String query, @RequestParam(defaultValue = "latest") String sort) {
      List<ExploreResponseDto.ExploreListDto> travels = exploreService.searchTravels(query, sort);
      if(travels.isEmpty()){
-         return ApiResponse.onFailure("400", "생성된 여행기 없음.", null);
+         throw new NotFoundHandler(ErrorStatus.NOT_FOUND_TRAVEL);
      }
         return ApiResponse.onSuccess(travels);
     }
@@ -34,9 +36,6 @@ public class ExploreController {
     @Operation(summary = "요즘 떠오르는 도시 API", description = "도시별 여행기순 내림차순")
     public ApiResponse<List<ExploreResponseDto.PopularCitiesDto>> getPopularCities(){
         List<ExploreResponseDto.PopularCitiesDto> cities = exploreService.getCitiesByTravelCount();
-        if(cities.isEmpty()){
-            return ApiResponse.onFailure("400", "생성된 여행기 없음.", null);
-        }
         return ApiResponse.onSuccess(cities);
     }
 }


### PR DESCRIPTION
## 연관 이슈

#92 

<br/>

## 개요

탐색 API ErrorStatus 설정, 요즘 떠오르는 도시 개수 제한

<br/>

## ✅ 작업 내용

- [x] 탐색 뷰 ErrorStatus 설정
  - [x] 도시, 국가 검색
  - [x] 요즘 떠오르는 도시
- [x] 요즘 떠오르는 도시 개수 - 8개로 제한

<br/>

### 📝 논의사항

1. ErrorStatus 처리 방법과 관련해서 궁금한 사항이 있는데요.. pr #86 참고했는데, 결국 handler를 사용하기로 된건가요? 우선 #86 처럼 적용하긴 했습니다! 또.. 저는 해당 pr 이후, 다음 작업은 데모데이 이전에 제가 작업했던 api 모두 Error 처리를 지금과 같이 통일해놓으려고 하는데, 아직 대부분의 controller를 보면 처리가 되어있지 않은 것 같아서요.. 이대로 계속 작업해도 될지 모르겠네요ㅜㅜ(추가적으로, Error처리 관련 로직을 controller에서 하면 좋을지, service에서 하면 좋을지도..)

2. 이건 제가 해결하지 못 한 문제인데요. pr #84 까지만 해도 검색 시, 입력이 "서울과 도쿄 여행기" 이런식으로 복잡한 입력이 주어져도 처리가 가능했었는데, 최신순/오래된순 기능 추가하면서 갑자기 저 로직이 돌아가지 않아서요 ㅜㅜ 이런 저런 로직으로 계속 수정해도 안 되어서 혹시 좋은 아이디어 있으면 공유 부탁드립니다..

