### PR TITLE
[feature] Add mapId to API responses and support updates by user info

### DIFF
--- a/src/main/java/umc/TripPiece/repository/MapRepository.java
+++ b/src/main/java/umc/TripPiece/repository/MapRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import umc.TripPiece.domain.Map;
 
 import java.util.List;
+import java.util.Optional; // 추가된 임포트
 
 public interface MapRepository extends JpaRepository<Map, Long> {
 
@@ -26,6 +27,10 @@ public interface MapRepository extends JpaRepository<Map, Long> {
     // 유저가 방문한 도시 수를 조회하는 메소드
     @Query("SELECT COUNT(DISTINCT m.city.id) FROM Map m WHERE m.userId = :userId")
     long countDistinctCityByUserId(Long userId);
+
+    // 유저 ID와 국가 코드, 도시 ID로 맵을 조회하는 메소드
+    @Query("SELECT m FROM Map m WHERE m.userId = :userId AND m.countryCode = :countryCode AND m.city.id = :cityId")
+    Optional<Map> findByUserIdAndCountryCodeAndCityId(Long userId, String countryCode, Long cityId);
 
     // 유저 ID와 국가 코드로 맵을 조회하는 메소드 (마커 반환을 위한 사용)
     Map findByCountryCodeAndUserId(String countryCode, Long userId);

--- a/src/main/java/umc/TripPiece/web/controller/MapController.java
+++ b/src/main/java/umc/TripPiece/web/controller/MapController.java
@@ -9,10 +9,10 @@ import org.springframework.web.bind.annotation.*;
 
 import umc.TripPiece.apiPayload.code.status.ErrorStatus;
 import umc.TripPiece.apiPayload.exception.handler.NotFoundHandler;
+import umc.TripPiece.domain.jwt.JWTUtil;
 import umc.TripPiece.service.MapService;
 import umc.TripPiece.validation.annotation.ExistEntity;
 import umc.TripPiece.web.dto.request.MapRequestDto;
-
 
 import org.springframework.validation.annotation.Validated;
 
@@ -33,6 +33,7 @@ import java.util.List;
 public class MapController {
 
     private final MapService mapService;
+    private final JWTUtil jwtUtil; // 추가: jwtUtil 객체 주입
 
     @GetMapping("/{userId}")
     @Operation(summary = "유저별 맵 불러오기 API", description = "유저별 맵 리스트 반환")
@@ -85,9 +86,11 @@ public class MapController {
         return ApiResponse.onSuccess(updatedMap);
     }
 
-    @GetMapping("/{userId}/visited-countries")
+    @GetMapping("/visited-countries")
     @Operation(summary = "방문한 나라 누적 API", description = "사용자가 방문한 나라의 리스트와 카운트를 반환")
-    public ApiResponse<MapStatsResponseDto> getVisitedCountries(@PathVariable(name = "userId") Long userId) {
+    public ApiResponse<MapStatsResponseDto> getVisitedCountries(@RequestHeader("Authorization") String token) {
+        String tokenWithoutBearer = token.substring(7); // Bearer 제거
+        Long userId = jwtUtil.getUserIdFromToken(tokenWithoutBearer); // jwtUtil 사용
         MapStatsResponseDto response = mapService.getVisitedCountriesWithProfile(userId);
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/umc/TripPiece/web/controller/MapController.java
+++ b/src/main/java/umc/TripPiece/web/controller/MapController.java
@@ -64,7 +64,6 @@ public class MapController {
         return ApiResponse.onSuccess(markers);
     }
 
-    // 맵 색상 수정 엔드포인트
     @PutMapping("/color/{mapId}")
     @Operation(summary = "맵 색상 수정 API", description = "맵의 색상을 수정")
     public ApiResponse<MapResponseDto> updateMapColor(@PathVariable(name = "mapId") Long mapId, @RequestBody @Valid MapColorDto colorDto) {
@@ -72,7 +71,6 @@ public class MapController {
         return ApiResponse.onSuccess(updatedMap);
     }
 
-    // 맵 색상 삭제 엔드포인트
     @DeleteMapping("/color/delete/{mapId}")
     @Operation(summary = "맵 색상 삭제 API", description = "맵의 색상을 삭제")
     public ApiResponse<Void> deleteMapColor(@PathVariable(name = "mapId") Long mapId) {
@@ -80,7 +78,6 @@ public class MapController {
         return ApiResponse.onSuccess(null);
     }
 
-    // 여러 색상 선택 엔드포인트
     @PutMapping("/colors/{mapId}")
     @Operation(summary = "맵 여러 색상 선택 API", description = "맵의 색상을 여러 개 선택")
     public ApiResponse<MapResponseDto> updateMultipleMapColors(@PathVariable(name = "mapId") Long mapId, @RequestBody MapColorsDto colorsDto) {
@@ -91,14 +88,7 @@ public class MapController {
     @GetMapping("/{userId}/visited-countries")
     @Operation(summary = "방문한 나라 누적 API", description = "사용자가 방문한 나라의 리스트와 카운트를 반환")
     public ApiResponse<MapStatsResponseDto> getVisitedCountries(@PathVariable(name = "userId") Long userId) {
-        List<String> countryCodes = mapService.getVisitedCountries(userId);
-        long countryCount = mapService.getVisitedCountryCount(userId);
-
-        MapStatsResponseDto response = MapStatsResponseDto.builder()
-                .countryCodes(countryCodes)
-                .countryCount(countryCount)
-                .build();
-
+        MapStatsResponseDto response = mapService.getVisitedCountriesWithProfile(userId);
         return ApiResponse.onSuccess(response);
     }
 


### PR DESCRIPTION
## 연관 이슈

지도 색상 수정 및 삭제 시 필요한 mapId 제공 문제 해결

## 개요

기존 API에서 mapId가 클라이언트에 노출되지 않아 발생한 수정/삭제 요청 문제를 해결하였습니다.
mapId를 API 응답에 포함하도록 변경하고, 기존 userId, countryCode, cityId를 기반으로도 수정/삭제가 가능하도록 API를 개선하였습니다.
