### PR TITLE
[feature] 맵 수정/삭제 API 기존 정보 기반으로 확장 및 예외 처리 추가

### DIFF
--- a/src/main/java/umc/TripPiece/repository/MapRepository.java
+++ b/src/main/java/umc/TripPiece/repository/MapRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import umc.TripPiece.domain.Map;
 
 import java.util.List;
-import java.util.Optional; // 추가된 임포트
+import java.util.Optional;
 
 public interface MapRepository extends JpaRepository<Map, Long> {
 
@@ -31,6 +31,10 @@ public interface MapRepository extends JpaRepository<Map, Long> {
     // 유저 ID와 국가 코드, 도시 ID로 맵을 조회하는 메소드
     @Query("SELECT m FROM Map m WHERE m.userId = :userId AND m.countryCode = :countryCode AND m.city.id = :cityId")
     Optional<Map> findByUserIdAndCountryCodeAndCityId(Long userId, String countryCode, Long cityId);
+
+    // 유저 ID와 국가 코드, 도시 ID로 중복된 모든 맵 조회
+    @Query("SELECT m FROM Map m WHERE m.userId = :userId AND m.countryCode = :countryCode AND m.city.id = :cityId")
+    List<Map> findAllByUserIdAndCountryCodeAndCityId(Long userId, String countryCode, Long cityId);
 
     // 유저 ID와 국가 코드로 맵을 조회하는 메소드 (마커 반환을 위한 사용)
     Map findByCountryCodeAndUserId(String countryCode, Long userId);

--- a/src/main/java/umc/TripPiece/service/MapService.java
+++ b/src/main/java/umc/TripPiece/service/MapService.java
@@ -40,6 +40,12 @@ public class MapService {
 
     @Transactional
     public MapResponseDto createMapWithCity(MapRequestDto requestDto) {
+        mapRepository.findByUserIdAndCountryCodeAndCityId(
+                        requestDto.getUserId(), requestDto.getCountryCode(), requestDto.getCityId())
+                .ifPresent(existingMap -> {
+                    throw new IllegalArgumentException("이미 색칠된 도시입니다.");
+                });
+
         City city = cityRepository.findById(requestDto.getCityId())
                 .orElseThrow(() -> new IllegalArgumentException("City not found with id: " + requestDto.getCityId()));
 
@@ -79,10 +85,12 @@ public class MapService {
 
     @Transactional
     public void deleteMapWithInfo(Long userId, String countryCode, Long cityId) {
-        Map map = mapRepository.findByUserIdAndCountryCodeAndCityId(userId, countryCode, cityId)
-                .orElseThrow(() -> new IllegalArgumentException("Map not found with provided info."));
+        List<Map> maps = mapRepository.findAllByUserIdAndCountryCodeAndCityId(userId, countryCode, cityId);
+        if (maps.isEmpty()) {
+            throw new IllegalArgumentException("해당 정보로 등록된 맵이 없습니다.");
+        }
 
-        mapRepository.delete(map);
+        mapRepository.deleteAll(maps);
     }
 
     @Transactional

--- a/src/main/java/umc/TripPiece/web/controller/MapController.java
+++ b/src/main/java/umc/TripPiece/web/controller/MapController.java
@@ -33,7 +33,7 @@ import java.util.List;
 public class MapController {
 
     private final MapService mapService;
-    private final JWTUtil jwtUtil; // 추가: jwtUtil 객체 주입
+    private final JWTUtil jwtUtil; // JWTUtil 객체 주입
 
     @GetMapping("/{userId}")
     @Operation(summary = "유저별 맵 불러오기 API", description = "유저별 맵 리스트 반환")
@@ -61,7 +61,6 @@ public class MapController {
     public ApiResponse<List<MapResponseDto.getMarkerResponse>> getMarkers(@RequestHeader("Authorization") String token) {
         String tokenWithoutBearer = token.substring(7);
         List<MapResponseDto.getMarkerResponse> markers = mapService.getMarkers(tokenWithoutBearer);
-
         return ApiResponse.onSuccess(markers);
     }
 
@@ -90,7 +89,7 @@ public class MapController {
     @Operation(summary = "맵 색상 수정 (기존 정보 기반)", description = "맵의 색상을 수정 (userId, countryCode, cityId 기반)")
     public ApiResponse<MapResponseDto> updateMapColorWithInfo(@RequestHeader("Authorization") String token,
                                                               @RequestBody @Valid MapRequestDto requestDto) {
-        Long userId = jwtUtil.getUserIdFromToken(token.substring(7)); // Bearer 제거
+        Long userId = jwtUtil.getUserIdFromToken(token.substring(7));
         MapResponseDto updatedMap = mapService.updateMapColorWithInfo(userId, requestDto.getCountryCode(), requestDto.getCityId(), requestDto.getColor());
         return ApiResponse.onSuccess(updatedMap);
     }
@@ -99,7 +98,7 @@ public class MapController {
     @Operation(summary = "맵 삭제 (기존 정보 기반)", description = "맵을 삭제 (userId, countryCode, cityId 기반)")
     public ApiResponse<Void> deleteMapWithInfo(@RequestHeader("Authorization") String token,
                                                @RequestBody @Valid MapRequestDto requestDto) {
-        Long userId = jwtUtil.getUserIdFromToken(token.substring(7)); // Bearer 제거
+        Long userId = jwtUtil.getUserIdFromToken(token.substring(7));
         mapService.deleteMapWithInfo(userId, requestDto.getCountryCode(), requestDto.getCityId());
         return ApiResponse.onSuccess(null);
     }
@@ -107,8 +106,7 @@ public class MapController {
     @GetMapping("/visited-countries")
     @Operation(summary = "방문한 나라 누적 API", description = "사용자가 방문한 나라의 리스트와 카운트를 반환")
     public ApiResponse<MapStatsResponseDto> getVisitedCountries(@RequestHeader("Authorization") String token) {
-        String tokenWithoutBearer = token.substring(7); // Bearer 제거
-        Long userId = jwtUtil.getUserIdFromToken(tokenWithoutBearer);
+        Long userId = jwtUtil.getUserIdFromToken(token.substring(7));
         MapStatsResponseDto response = mapService.getVisitedCountriesWithProfile(userId);
         return ApiResponse.onSuccess(response);
     }


### PR DESCRIPTION
## 연관 이슈
기존에 mapId를 알 수 없었던 클라이언트가 userId, countryCode, cityId 정보만으로 수정/삭제가 가능

## 개요

맵 수정 및 삭제 API를 기존 정보(userId, countryCode, cityId)를 기반으로 동작하도록 확장. 이를 통해 클라이언트가 mapId를 모르더라도 수정 및 삭제 요청을 처리할 수 있도록 구현. 또한 중복 데이터 삭제 및 예외 처리를 추가하여 안정성을 개선


