### PR TITLE
[fix] 진행 중인 여행 처리 로직 변경

### DIFF
--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -1,34 +1,50 @@
 package umc.TripPiece.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import umc.TripPiece.apiPayload.ApiResponse;
 import umc.TripPiece.apiPayload.code.status.ErrorStatus;
 import umc.TripPiece.apiPayload.exception.handler.BadRequestHandler;
 import umc.TripPiece.apiPayload.exception.handler.NotFoundHandler;
 import umc.TripPiece.aws.s3.AmazonS3Manager;
 import umc.TripPiece.converter.TravelConverter;
 import umc.TripPiece.converter.TripPieceConverter;
-import umc.TripPiece.domain.*;
-import umc.TripPiece.domain.enums.Category;
-
+import umc.TripPiece.domain.City;
+import umc.TripPiece.domain.Country;
+import umc.TripPiece.domain.Emoji;
+import umc.TripPiece.domain.Picture;
+import umc.TripPiece.domain.Travel;
+import umc.TripPiece.domain.TripPiece;
+import umc.TripPiece.domain.User;
+import umc.TripPiece.domain.Uuid;
+import umc.TripPiece.domain.Video;
 import umc.TripPiece.domain.enums.Category;
 import umc.TripPiece.domain.enums.TravelStatus;
 import umc.TripPiece.domain.jwt.JWTUtil;
-import umc.TripPiece.repository.*;
+import umc.TripPiece.repository.CityRepository;
+import umc.TripPiece.repository.CountryRepository;
+import umc.TripPiece.repository.EmojiRepository;
+import umc.TripPiece.repository.PictureRepository;
+import umc.TripPiece.repository.TravelRepository;
+import umc.TripPiece.repository.TripPieceRepository;
+import umc.TripPiece.repository.UserRepository;
+import umc.TripPiece.repository.UuidRepository;
+import umc.TripPiece.repository.VideoRepository;
 import umc.TripPiece.security.SecurityUtils;
 import umc.TripPiece.web.dto.request.TravelRequestDto;
 import umc.TripPiece.web.dto.response.TravelResponseDto;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -57,12 +73,14 @@ public class TravelService {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_TRAVEL));
 
         // 완료된 여행기 예외 처리
-        if(travel.getStatus() == TravelStatus.COMPLETED)
+        if (travel.getStatus() == TravelStatus.COMPLETED) {
             throw new BadRequestHandler(ErrorStatus.TRAVEL_COMPLETED);
+        }
 
         // 메모 150자 예외 처리
-        if(request.getDescription().length() > 150)
+        if (request.getDescription().length() > 150) {
             throw new BadRequestHandler(ErrorStatus.TEXT_LENGTH_150_ERROR);
+        }
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
 
@@ -70,7 +88,7 @@ public class TravelService {
         newTripPiece.setCategory(Category.MEMO);
 
         // 여행기의 메모 조각 갯수 증가
-        travel.setMemoNum(travel.getMemoNum()+1);
+        travel.setMemoNum(travel.getMemoNum() + 1);
 
         return tripPieceRepository.save(newTripPiece);
     }
@@ -85,24 +103,28 @@ public class TravelService {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_TRAVEL));
 
         // 메모 검증
-        if (request.getDescription().length() > 100)
+        if (request.getDescription().length() > 100) {
             throw new BadRequestHandler(ErrorStatus.TEXT_LENGTH_100_ERROR);
+        }
 
         // 완료된 여행기 예외 처리
-        if(travel.getStatus() == TravelStatus.COMPLETED)
+        if (travel.getStatus() == TravelStatus.COMPLETED) {
             throw new BadRequestHandler(ErrorStatus.TRAVEL_COMPLETED);
+        }
 
         // 이모지 개수 검증
-        if (emojis.size() != 4)
+        if (emojis.size() != 4) {
             throw new BadRequestHandler(ErrorStatus.EMOJI_NUMBER_ERROR);
+        }
 
         // 이모지 정규식 검증
         for (String emoji : emojis) {
             Pattern rex = Pattern.compile("[\\x{10000}-\\x{10ffff}\ud800-\udfff]");
             Matcher rexMatcher = rex.matcher(emoji);
 
-            if (!rexMatcher.find())
+            if (!rexMatcher.find()) {
                 throw new BadRequestHandler(ErrorStatus.EMOJI_INPUT_ERROR);
+            }
         }
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
@@ -131,27 +153,28 @@ public class TravelService {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_TRAVEL));
 
         // 메모 검증
-        if (request.getDescription().length() > 100)
+        if (request.getDescription().length() > 100) {
             throw new BadRequestHandler(ErrorStatus.TEXT_LENGTH_100_ERROR);
+        }
 
         // 완료된 여행기 예외 처리
-        if (travel.getStatus() == TravelStatus.COMPLETED)
+        if (travel.getStatus() == TravelStatus.COMPLETED) {
             throw new BadRequestHandler(ErrorStatus.TRAVEL_COMPLETED);
-
+        }
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
 
         newTripPiece.setTravel(travel);
         newTripPiece.setCategory(Category.PICTURE);
 
-        travel.setPictureNum(travel.getPictureNum()+1);
+        travel.setPictureNum(travel.getPictureNum() + 1);
 
         int pictureNum = pictures.size();
 
         List<Uuid> uuids = new ArrayList<>();
 
         // UUID 생성
-        for(int i = 0; i < pictureNum; i++) {
+        for (int i = 0; i < pictureNum; i++) {
             String uuid = UUID.randomUUID().toString();
             Uuid savedUuid = uuidRepository.save(Uuid.builder()
                     .uuid(uuid).build());
@@ -159,9 +182,10 @@ public class TravelService {
         }
 
         // 사진 URL 저장
-        List<String> pictureUrls = s3Manager.saveFiles(s3Manager.generateTripPieceKeyNames(uuids), pictures, Category.PICTURE);
+        List<String> pictureUrls = s3Manager.saveFiles(s3Manager.generateTripPieceKeyNames(uuids), pictures,
+                Category.PICTURE);
 
-        for(int i = 0; i < pictureNum; i++) {
+        for (int i = 0; i < pictureNum; i++) {
             Picture newPicture = TripPieceConverter.toTripPiecePicture(pictureUrls.get(i), newTripPiece);
             pictureRepository.save(newPicture);
         }
@@ -179,18 +203,20 @@ public class TravelService {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_TRAVEL));
 
         // 메모 검증
-        if (request.getDescription().length() > 100)
+        if (request.getDescription().length() > 100) {
             throw new BadRequestHandler(ErrorStatus.TEXT_LENGTH_100_ERROR);
+        }
 
         // 완료된 여행기 예외 처리
-        if (travel.getStatus() == TravelStatus.COMPLETED)
+        if (travel.getStatus() == TravelStatus.COMPLETED) {
             throw new BadRequestHandler(ErrorStatus.TRAVEL_COMPLETED);
+        }
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travel);
         newTripPiece.setCategory(Category.SELFIE);
 
-        travel.setPictureNum(travel.getPictureNum()+1);
+        travel.setPictureNum(travel.getPictureNum() + 1);
 
         // UUID 생성
         String uuid = UUID.randomUUID().toString();
@@ -198,7 +224,8 @@ public class TravelService {
                 .uuid(uuid).build());
 
         // 사진 업로드
-        String pictureUrl = s3Manager.uploadFile(s3Manager.generateTripPieceKeyName(savedUuid), picture, Category.PICTURE);
+        String pictureUrl = s3Manager.uploadFile(s3Manager.generateTripPieceKeyName(savedUuid), picture,
+                Category.PICTURE);
 
         Picture newPicture = TripPieceConverter.toTripPiecePicture(pictureUrl, newTripPiece);
 
@@ -217,18 +244,20 @@ public class TravelService {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_TRAVEL));
 
         // 메모 검증
-        if (request.getDescription().length() > 100)
+        if (request.getDescription().length() > 100) {
             throw new BadRequestHandler(ErrorStatus.TEXT_LENGTH_100_ERROR);
+        }
 
         // 완료된 여행기 예외 처리
-        if (travel.getStatus() == TravelStatus.COMPLETED)
+        if (travel.getStatus() == TravelStatus.COMPLETED) {
             throw new BadRequestHandler(ErrorStatus.TRAVEL_COMPLETED);
+        }
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travel);
         newTripPiece.setCategory(Category.VIDEO);
 
-        travel.setVideoNum(travel.getVideoNum()+1);
+        travel.setVideoNum(travel.getVideoNum() + 1);
 
         // UUID 생성
         String uuid = UUID.randomUUID().toString();
@@ -256,18 +285,20 @@ public class TravelService {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_TRAVEL));
 
         // 메모 검증
-        if (request.getDescription().length() > 100)
+        if (request.getDescription().length() > 100) {
             throw new BadRequestHandler(ErrorStatus.TEXT_LENGTH_100_ERROR);
+        }
 
         // 완료된 여행기 예외 처리
-        if (travel.getStatus() == TravelStatus.COMPLETED)
+        if (travel.getStatus() == TravelStatus.COMPLETED) {
             throw new BadRequestHandler(ErrorStatus.TRAVEL_COMPLETED);
+        }
 
         TripPiece newTripPiece = TravelConverter.toTripPieceMemo(request, user);
         newTripPiece.setTravel(travel);
         newTripPiece.setCategory(Category.WHERE);
 
-        travel.setVideoNum(travel.getVideoNum()+1);
+        travel.setVideoNum(travel.getVideoNum() + 1);
 
         // UUID 생성
         String uuid = UUID.randomUUID().toString();
@@ -289,8 +320,10 @@ public class TravelService {
     public TravelResponseDto.Create createTravel(TravelRequestDto.Create request, MultipartFile thumbnail) {
         Long userId = SecurityUtils.getCurrentUserId();
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
-        City city = cityRepository.findByNameIgnoreCase(request.getCityName()).stream().findFirst().orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_CITY));
-        Country country = countryRepository.findByNameIgnoreCase(request.getCountryName()).stream().findFirst().orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_COUNTRY));
+        City city = cityRepository.findByNameIgnoreCase(request.getCityName()).stream().findFirst()
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_CITY));
+        Country country = countryRepository.findByNameIgnoreCase(request.getCountryName()).stream().findFirst()
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_COUNTRY));
 
         if (!city.getCountry().getId().equals(country.getId())) {
             throw new BadRequestHandler(ErrorStatus.INVALID_CITY_COUNTRY_RELATION);
@@ -306,8 +339,12 @@ public class TravelService {
         String uuid = UUID.randomUUID().toString();
         String thumbnailUrl = s3Manager.uploadFile("thumbnails/" + uuid, thumbnail, Category.PICTURE);
 
-        Travel OngoingTravel = travelRepository.findByStatusAndUserId(TravelStatus.ONGOING, userId)
-                .orElseThrow(() -> new BadRequestHandler(ErrorStatus.TRAVEL_INPROGRESS));
+        Travel ongoingTravel = travelRepository.findByStatusAndUserId(TravelStatus.ONGOING, userId)
+                .orElse(null);
+
+        if (ongoingTravel != null) {
+            throw new BadRequestHandler(ErrorStatus.TRAVEL_INPROGRESS);
+        }
 
         Travel travel = TravelConverter.toTravel(request, city);
         travel.setUser(user);
@@ -370,7 +407,10 @@ public class TravelService {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
 
         Travel travel = travelRepository.findByStatusAndUserId(TravelStatus.ONGOING, userId)
-                .orElseThrow(() -> new BadRequestHandler(ErrorStatus.TRAVEL_INPROGRESS));
+                .orElse(null);
+        if (travel == null) {
+            throw new BadRequestHandler(ErrorStatus.NOT_FOUND_TRAVEL);
+        }
 
         City city = travel.getCity();
         Country country = city.getCountry();
@@ -411,17 +451,26 @@ public class TravelService {
 
     @Transactional
     public List<TravelResponseDto.UpdatablePictureDto> updateThumbnail(Long travelId, List<Long> pictureIdList) {
-        if (pictureIdList.size() != 9) throw new IllegalArgumentException("리스트의 크기는 9여야 합니다.");
+        if (pictureIdList.size() != 9) {
+            throw new IllegalArgumentException("리스트의 크기는 9여야 합니다.");
+        }
 
-        Travel travel = travelRepository.findById(travelId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 여행기입니다."));
+        Travel travel = travelRepository.findById(travelId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 여행기입니다."));
 
         List<Picture> pictures = pictureIdList.stream()
                 .map(id -> {
                     // id = -1이면 null 객체를 담음
-                    if (id == -1) return null;
+                    if (id == -1) {
+                        return null;
+                    }
 
-                    Picture picture = pictureRepository.findById(id).orElseThrow(() -> new IllegalArgumentException(String.format("사진을 찾을 수 없습니다. (id = %d)", id)));
-                    if (!getPictures(travel).contains(picture)) throw new IllegalArgumentException(String.format("해당 여행기에 존재하지 않는 사진입니다. (id = %d)", picture.getId()));
+                    Picture picture = pictureRepository.findById(id).orElseThrow(
+                            () -> new IllegalArgumentException(String.format("사진을 찾을 수 없습니다. (id = %d)", id)));
+                    if (!getPictures(travel).contains(picture)) {
+                        throw new IllegalArgumentException(
+                                String.format("해당 여행기에 존재하지 않는 사진입니다. (id = %d)", picture.getId()));
+                    }
 
                     return picture;
                 })
@@ -439,7 +488,9 @@ public class TravelService {
             Picture newPicture = pictures.get(i);
 
             // 같은 객체이면 해당 위치의 썸네일 유지
-            if (originPicture != null && originPicture.equals(newPicture)) continue;
+            if (originPicture != null && originPicture.equals(newPicture)) {
+                continue;
+            }
 
             // 기존의 사진을 썸네일에서 해제
             if (originPicture != null) {
@@ -483,7 +534,9 @@ public class TravelService {
             thumbnailIndex++;
 
             // 사진이 9장보다 적을 때, 다 설정이 되면 메서드 종료
-            if (pictures.isEmpty()) return;
+            if (pictures.isEmpty()) {
+                return;
+            }
         }
     }
 
@@ -499,7 +552,8 @@ public class TravelService {
         List<Picture> pictures = new ArrayList<>();
 
         travel.getTripPieces().stream()
-                .filter(tripPiece -> tripPiece.getCategory() == Category.PICTURE || tripPiece.getCategory() == Category.SELFIE)
+                .filter(tripPiece -> tripPiece.getCategory() == Category.PICTURE
+                        || tripPiece.getCategory() == Category.SELFIE)
                 .forEach(tripPiece -> {
                     List<Picture> pictureList = tripPiece.getPictures();
                     pictures.addAll(pictureList);


### PR DESCRIPTION
## 연관 이슈

close #120

<br/>

## 개요

여행 종료 및 여행 관련 에러 해결

<br/>

## ✅ 작업 내용

- [x] 진행 중인 여행 처리 로직 변경

여행 종료 관련해서 500에러 해결하려고 보니 원인은 `TravelRepository`에 있는 `findByStatusAndUserId` 함수 사용이었습니다!

진행 중인 여행기와 여행 생성 컨트롤러에서 해당 함수를 사용하고 있었는데 여행기가 없는 경우에도 `TRAVEL_INPROGRESS` 예외를 던지고 있어서 스웨거 확인해보니 이 문제 때문에 여행기 종료가 안 되던 것 같습니다!

진행 중인 여행기 반환이나 여행기 생성 또한 안 되고 있었는데.. 프론트에서 문제가 있었을텐데.. 왜 여행 종료만 안 된다고 하신지 모르겠습니다만..


<br/>

### 📝 논의사항

석우 님이 같은 로직 사용하고 계셔서 확인 부탁드립니다!
진행 중인 여행기에도 반영해놨어요!
