### PR TITLE
[feature] 이메일 인증번호 발송 API 중복 이메일일 시 응답 200 반환

### DIFF
--- a/src/main/java/umc/TripPiece/apiPayload/ApiResponse.java
+++ b/src/main/java/umc/TripPiece/apiPayload/ApiResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import umc.TripPiece.apiPayload.code.BaseCode;
+import umc.TripPiece.apiPayload.code.BaseErrorCode;
 import umc.TripPiece.apiPayload.code.status.SuccessStatus;
 
 @Getter
@@ -28,8 +29,8 @@ public class ApiResponse<T> {
     }
 
     // 실패이지만, 성공 응답 반환 필요할 때
-    public static <T> ApiResponse<T> of(String code, String message) {
-        return new ApiResponse<>(true, code, message, null);
+    public static <T> ApiResponse<T> of(BaseErrorCode code) {
+        return new ApiResponse<>(true, code.getReason().getCode()+"", code.getReason().getMessage()+"", null);
     }
 
 

--- a/src/main/java/umc/TripPiece/apiPayload/ApiResponse.java
+++ b/src/main/java/umc/TripPiece/apiPayload/ApiResponse.java
@@ -27,8 +27,9 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
     }
 
-    public static <T> ApiResponse<T> of(BaseCode code, T result){
-            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    // 실패이지만, 성공 응답 반환 필요할 때
+    public static <T> ApiResponse<T> of(String code, String message) {
+        return new ApiResponse<>(true, code, message, null);
     }
 
 

--- a/src/main/java/umc/TripPiece/web/controller/EmailController.java
+++ b/src/main/java/umc/TripPiece/web/controller/EmailController.java
@@ -33,7 +33,7 @@ public class EmailController {
 
         // 중복된 이메일일 경우
         if (userRepository.existsByEmail(email)) {
-            return ResponseEntity.ok(ApiResponse.of(ErrorStatus.DUPLICATION_EMAIL.getCode(), "이미 등록된 이메일입니다."));
+            return ResponseEntity.ok(ApiResponse.of(ErrorStatus.DUPLICATION_EMAIL));
         }
 
         String code = emailService.generateVerificationCode();

--- a/src/main/java/umc/TripPiece/web/controller/EmailController.java
+++ b/src/main/java/umc/TripPiece/web/controller/EmailController.java
@@ -33,7 +33,7 @@ public class EmailController {
 
         // 중복된 이메일일 경우
         if (userRepository.existsByEmail(email)) {
-            throw new UserHandler(ErrorStatus.DUPLICATION_EMAIL);
+            return ResponseEntity.ok(ApiResponse.of(ErrorStatus.DUPLICATION_EMAIL.getCode(), "이미 등록된 이메일입니다."));
         }
 
         String code = emailService.generateVerificationCode();


### PR DESCRIPTION
## 연관 이슈

close #123

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
이메일 인증번호 발송 API 중복 이메일일 시 응답 200 반환
<br/>

## ✅ 작업 내용
![image](https://github.com/user-attachments/assets/19c76315-f9ef-4d8f-aa33-e9932e744f91)

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 기존에 409 에러로 반환했는데, 실패 응답에 대한 에러코드를 프론트에서 받아오기 어렵다고 하여, 성공 응답 200이 나오게 하고 응답값에서 code를 `EMAIL409`로 보냈습니다!
해당 경우 `ApiResponse<T> of` 사용하면 될 것 같습니다.
