### PR TITLE
[fix] 국가별 색상 정렬 방식 수정 (최신 데이터가 리스트 마지막에 위치)

### DIFF
--- a/src/main/java/umc/TripPiece/repository/MapRepository.java
+++ b/src/main/java/umc/TripPiece/repository/MapRepository.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 
 public interface MapRepository extends JpaRepository<Map, Long> {
 
-    // 유저 ID로 맵을 조회하는 메소드 (저장된 시간 순서로 정렬)
-    @Query("SELECT m FROM Map m WHERE m.userId = :userId ORDER BY m.countryCode ASC, m.createdAt DESC")
+    // 유저 ID로 맵을 조회하는 메소드 (저장된 시간 순서로 정렬 - 최신 데이터가 리스트 마지막에 위치)
+    @Query("SELECT m FROM Map m WHERE m.userId = :userId ORDER BY m.countryCode ASC, m.createdAt ASC")
     List<Map> findByUserIdOrderedByCreatedAt(Long userId);
 
     // 유저가 방문한 나라 수를 조회하는 메소드
@@ -37,7 +37,7 @@ public interface MapRepository extends JpaRepository<Map, Long> {
     @Query("SELECT m FROM Map m WHERE m.userId = :userId AND m.countryCode = :countryCode AND m.city.id = :cityId")
     List<Map> findAllByUserIdAndCountryCodeAndCityId(Long userId, String countryCode, Long cityId);
 
-    // 유저 ID와 국가 코드로 맵을 조회하는 메소드 (마커 반환을 위한 사용)
-    @Query("SELECT m FROM Map m WHERE m.countryCode = :countryCode AND m.userId = :userId ORDER BY m.createdAt DESC")
+    // 특정 국가에서 유저가 색칠한 도시를 정렬된 순서로 조회 (최신이 마지막에 위치)
+    @Query("SELECT m FROM Map m WHERE m.countryCode = :countryCode AND m.userId = :userId ORDER BY m.createdAt ASC")
     List<Map> findByCountryCodeAndUserIdOrderedByCreatedAt(String countryCode, Long userId);
 }

--- a/src/main/java/umc/TripPiece/service/MapService.java
+++ b/src/main/java/umc/TripPiece/service/MapService.java
@@ -168,7 +168,7 @@ public class MapService {
 
     public List<MapResponseDto.searchDto> searchCitiesCountry(String keyword) {
         if (keyword == null || keyword.trim().isEmpty()) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         List<City> cities = cityRepository.findByNameIgnoreCase(keyword);


### PR DESCRIPTION
**같은 국가 코드 내에서 최신 데이터가 마지막에 위치하도록 정렬**
findByUserIdOrderedByCreatedAt(), findByCountryCodeAndUserIdOrderedByCreatedAt() 추가
ORDER BY createdAt DESC 정렬 적용

**맵 조회 및 마커 조회 시 최신 데이터 기준으로 반환**
getUserMaps(), getMapsByUserId(), getUserMarkers()에서 최신 순서 적용

**수정 기능에서 최신 데이터만 선택 가능하도록 정렬 개선**
findByCountryCodeAndUserIdOrderedByCreatedAt() 활용하여 가장 최근 저장된 색상 반환.