### PR TITLE
[fix] 국가별 최신 색상 정렬 오류 수정 및 코드 최적화

### DIFF
--- a/src/main/java/umc/TripPiece/repository/MapRepository.java
+++ b/src/main/java/umc/TripPiece/repository/MapRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface MapRepository extends JpaRepository<Map, Long> {
 
     // 유저 ID로 맵을 조회하는 메소드 (저장된 시간 순서로 정렬 - 최신 데이터가 리스트 마지막에 위치)
-    @Query("SELECT m FROM Map m WHERE m.userId = :userId ORDER BY m.countryCode ASC, m.createdAt ASC")
+    @Query("SELECT m FROM Map m WHERE m.userId = :userId ORDER BY m.countryCode ASC, m.createdAt DESC")
     List<Map> findByUserIdOrderedByCreatedAt(Long userId);
 
     // 유저가 방문한 나라 수를 조회하는 메소드
@@ -37,7 +37,7 @@ public interface MapRepository extends JpaRepository<Map, Long> {
     @Query("SELECT m FROM Map m WHERE m.userId = :userId AND m.countryCode = :countryCode AND m.city.id = :cityId")
     List<Map> findAllByUserIdAndCountryCodeAndCityId(Long userId, String countryCode, Long cityId);
 
-    // 특정 국가에서 유저가 색칠한 도시를 정렬된 순서로 조회 (최신이 마지막에 위치)
-    @Query("SELECT m FROM Map m WHERE m.countryCode = :countryCode AND m.userId = :userId ORDER BY m.createdAt ASC")
+    // 특정 국가에서 유저가 색칠한 도시를 정렬된 순서로 조회 (최신 데이터가 리스트 마지막에 위치)
+    @Query("SELECT m FROM Map m WHERE m.countryCode = :countryCode AND m.userId = :userId ORDER BY m.createdAt DESC")
     List<Map> findByCountryCodeAndUserIdOrderedByCreatedAt(String countryCode, Long userId);
 }

--- a/src/main/java/umc/TripPiece/service/MapService.java
+++ b/src/main/java/umc/TripPiece/service/MapService.java
@@ -64,8 +64,7 @@ public class MapService {
                 .orElseThrow(() -> new IllegalArgumentException("Map not found with id: " + mapId));
 
         map.setColor(newColor);
-        Map updatedMap = mapRepository.save(map);
-        return MapConverter.toMapResponseDto(updatedMap);
+        return MapConverter.toMapResponseDto(mapRepository.save(map));
     }
 
     @Transactional
@@ -76,8 +75,7 @@ public class MapService {
                 .orElseThrow(() -> new IllegalArgumentException("Map not found with provided info."));
 
         map.setColor(newColor);
-        Map updatedMap = mapRepository.save(map);
-        return MapConverter.toMapResponseDto(updatedMap);
+        return MapConverter.toMapResponseDto(mapRepository.save(map));
     }
 
     @Transactional
@@ -107,8 +105,7 @@ public class MapService {
                 .orElseThrow(() -> new IllegalArgumentException("Map not found with id: " + mapId));
 
         map.setColors(colorStrings);
-        Map updatedMap = mapRepository.save(map);
-        return MapConverter.toMapResponseDto(updatedMap);
+        return MapConverter.toMapResponseDto(mapRepository.save(map));
     }
 
     public List<MapResponseDto> getMapsByUserId(Long userId) {
@@ -174,28 +171,15 @@ public class MapService {
         List<City> cities = cityRepository.findByNameIgnoreCase(keyword);
         List<Country> countries = countryRepository.findByNameIgnoreCase(keyword);
 
-        List<MapResponseDto.searchDto> results = new ArrayList<>();
-
-        if (!cities.isEmpty()) {
-            results.addAll(cities.stream().map(MapConverter::toSearchDto).collect(Collectors.toList()));
-        }
-
-        if (!countries.isEmpty()) {
-            for (Country country : countries) {
-                List<City> citiesInCountry = cityRepository.findByCountryId(country.getId());
-                results.addAll(citiesInCountry.stream().map(MapConverter::toSearchDto).collect(Collectors.toList()));
-            }
-        }
-
-        return results;
+        return cities.stream()
+                .map(MapConverter::toSearchDto)
+                .collect(Collectors.toList());
     }
 
     public List<MapResponseDto.getMarkerResponse> getUserMarkers() {
         Long userId = SecurityUtils.getCurrentUserId();
 
-        List<Map> maps = mapRepository.findByUserIdOrderedByCreatedAt(userId);
-
-        return maps.stream()
+        return mapRepository.findByUserIdOrderedByCreatedAt(userId).stream()
                 .map(map -> MapConverter.toMarkerResponseDto(
                         map,
                         "",


### PR DESCRIPTION
**정렬 순서 수정 (createdAt DESC)**
findByUserIdOrderedByCreatedAt(), findByCountryCodeAndUserIdOrderedByCreatedAt()에서 최신 데이터가 리스트의 마지막에 오도록 정렬 변경
기존 ASC → DESC로 변경하여 같은 countryCode 내에서 가장 최근 추가된 색상이 마지막에 위치하도록 조정

**불필요한 리스트 생성 제거**
searchCitiesCountry()에서 빈 값 반환 시 Collections.emptyList() 사용하여 불필요한 객체 생성 방지

**코드 최적화 및 가독성 개선**
mapRepository.save(map)를 한 줄로 축약하여 중복 코드 제거 및 코드 가독성 향상
getUserMarkers()에서도 최신 정렬 순서 반영