### PR TITLE
[fix] 최신 수정 데이터 정렬 오류 해결

### DIFF
--- a/src/main/java/umc/TripPiece/repository/MapRepository.java
+++ b/src/main/java/umc/TripPiece/repository/MapRepository.java
@@ -9,35 +9,45 @@ import java.util.Optional;
 
 public interface MapRepository extends JpaRepository<Map, Long> {
 
-    // 유저 ID로 맵을 조회하는 메소드 (저장된 시간 순서로 정렬 - 최신 데이터가 리스트 마지막에 위치)
-    @Query("SELECT m FROM Map m WHERE m.userId = :userId ORDER BY m.countryCode ASC, m.createdAt DESC")
-    List<Map> findByUserIdOrderedByCreatedAt(Long userId);
+    // 유저 ID로 맵을 조회 (updatedAt 최신순, NULL이면 createdAt 기준 정렬)
+    @Query("""
+            SELECT m FROM Map m 
+            WHERE m.userId = :userId 
+            ORDER BY 
+                CASE WHEN m.updatedAt IS NULL THEN m.createdAt ELSE m.updatedAt END DESC
+            """)
+    List<Map> findByUserIdOrderedByUpdatedAt(Long userId);
 
-    // 유저가 방문한 나라 수를 조회하는 메소드
+    // 유저가 방문한 나라 수 조회
     @Query("SELECT COUNT(DISTINCT m.countryCode) FROM Map m WHERE m.userId = :userId")
     long countDistinctCountryCodeByUserId(Long userId);
 
-    // 유저가 방문한 나라의 countryCode 리스트를 조회하는 메소드
+    // 유저가 방문한 나라 리스트 조회
     @Query("SELECT DISTINCT m.countryCode FROM Map m WHERE m.userId = :userId")
     List<String> findDistinctCountryCodesByUserId(Long userId);
 
-    // 유저가 방문한 도시의 city.id 리스트를 조회하는 메소드
+    // 유저가 방문한 도시 리스트 조회
     @Query("SELECT DISTINCT m.city.id FROM Map m WHERE m.userId = :userId")
     List<Long> findDistinctCityIdsByUserId(Long userId);
 
-    // 유저가 방문한 도시 수를 조회하는 메소드
+    // 유저가 방문한 도시 수 조회
     @Query("SELECT COUNT(DISTINCT m.city.id) FROM Map m WHERE m.userId = :userId")
     long countDistinctCityByUserId(Long userId);
 
-    // 유저 ID와 국가 코드, 도시 ID로 맵을 조회하는 메소드
+    // 특정 유저가 특정 도시를 방문한 기록 찾기
     @Query("SELECT m FROM Map m WHERE m.userId = :userId AND m.countryCode = :countryCode AND m.city.id = :cityId")
     Optional<Map> findByUserIdAndCountryCodeAndCityId(Long userId, String countryCode, Long cityId);
 
-    // 유저 ID와 국가 코드, 도시 ID로 중복된 모든 맵 조회
+    // 특정 유저가 특정 도시를 방문한 모든 기록 찾기
     @Query("SELECT m FROM Map m WHERE m.userId = :userId AND m.countryCode = :countryCode AND m.city.id = :cityId")
     List<Map> findAllByUserIdAndCountryCodeAndCityId(Long userId, String countryCode, Long cityId);
 
-    // 특정 국가에서 유저가 색칠한 도시를 정렬된 순서로 조회 (최신 데이터가 리스트 마지막에 위치)
-    @Query("SELECT m FROM Map m WHERE m.countryCode = :countryCode AND m.userId = :userId ORDER BY m.createdAt DESC")
-    List<Map> findByCountryCodeAndUserIdOrderedByCreatedAt(String countryCode, Long userId);
+    // 특정 국가에서 유저가 색칠한 도시를 정렬된 순서로 조회 (updatedAt 최신, NULL이면 createdAt 기준 정렬)
+    @Query("""
+            SELECT m FROM Map m 
+            WHERE m.countryCode = :countryCode AND m.userId = :userId 
+            ORDER BY 
+                CASE WHEN m.updatedAt IS NULL THEN m.createdAt ELSE m.updatedAt END DESC
+            """)
+    List<Map> findByCountryCodeAndUserIdOrderedByUpdatedAt(String countryCode, Long userId);
 }

--- a/src/main/java/umc/TripPiece/service/MapService.java
+++ b/src/main/java/umc/TripPiece/service/MapService.java
@@ -7,17 +7,13 @@ import umc.TripPiece.converter.MapConverter;
 import umc.TripPiece.domain.City;
 import umc.TripPiece.domain.Country;
 import umc.TripPiece.domain.Map;
-import umc.TripPiece.domain.Travel;
 import umc.TripPiece.domain.User;
-import umc.TripPiece.domain.enums.Color;
-import umc.TripPiece.domain.jwt.JWTUtil;
 import umc.TripPiece.repository.*;
 import umc.TripPiece.security.SecurityUtils;
 import umc.TripPiece.web.dto.request.MapRequestDto;
 import umc.TripPiece.web.dto.response.MapResponseDto;
 import umc.TripPiece.web.dto.response.MapStatsResponseDto;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,8 +30,7 @@ public class MapService {
 
     public List<MapResponseDto> getUserMaps() {
         Long userId = SecurityUtils.getCurrentUserId();
-
-        return mapRepository.findByUserIdOrderedByCreatedAt(userId).stream()
+        return mapRepository.findByUserIdOrderedByUpdatedAt(userId).stream() // ✅ 메서드 이름 변경
                 .map(MapConverter::toMapResponseDto)
                 .collect(Collectors.toList());
     }
@@ -100,16 +95,16 @@ public class MapService {
     }
 
     @Transactional
-    public MapResponseDto updateMultipleMapColors(Long mapId, List<String> colorStrings) {
+    public MapResponseDto updateMultipleMapColors(Long mapId, List<String> colors) {
         Map map = mapRepository.findById(mapId)
                 .orElseThrow(() -> new IllegalArgumentException("Map not found with id: " + mapId));
 
-        map.setColors(colorStrings);
+        map.setColors(colors);
         return MapConverter.toMapResponseDto(mapRepository.save(map));
     }
 
     public List<MapResponseDto> getMapsByUserId(Long userId) {
-        return mapRepository.findByUserIdOrderedByCreatedAt(userId).stream()
+        return mapRepository.findByUserIdOrderedByUpdatedAt(userId).stream() // ✅ 메서드 이름 변경
                 .map(MapConverter::toMapResponseDto)
                 .collect(Collectors.toList());
     }
@@ -147,8 +142,8 @@ public class MapService {
     public MapStatsResponseDto getVisitedCountriesWithProfile() {
         Long userId = SecurityUtils.getCurrentUserId();
 
-        List<String> visitedCountries = getVisitedCountries(userId);
-        long visitedCountryCount = getVisitedCountryCount(userId);
+        List<String> visitedCountries = mapRepository.findDistinctCountryCodesByUserId(userId);
+        long visitedCountryCount = mapRepository.countDistinctCountryCodeByUserId(userId);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
@@ -179,7 +174,7 @@ public class MapService {
     public List<MapResponseDto.getMarkerResponse> getUserMarkers() {
         Long userId = SecurityUtils.getCurrentUserId();
 
-        return mapRepository.findByUserIdOrderedByCreatedAt(userId).stream()
+        return mapRepository.findByUserIdOrderedByUpdatedAt(userId).stream() // ✅ 메서드 이름 변경
                 .map(map -> MapConverter.toMarkerResponseDto(
                         map,
                         "",


### PR DESCRIPTION
updatedAt 기준 정렬 방향 ASC → DESC 변경
최신 데이터가 리스트 마지막에 오도록 수정
국가 코드 내에서 수정된 순서대로 정확히 정렬되도록 개선