### PR TITLE
[feature] 여행기 편집 API 구현

### DIFF
--- a/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/TripPiece/apiPayload/code/status/ErrorStatus.java
@@ -79,6 +79,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_TRAVEL_DATE(HttpStatus.BAD_REQUEST, "TRAVEL400", "여행 기간이 유효하지 않습니다."),
     INVALID_TRAVEL_TITLE(HttpStatus.BAD_REQUEST, "TRAVEL400", "여행기 제목이 유효하지 않습니다."),
     TRAVEL_COMPLETED(HttpStatus.BAD_REQUEST, "TRAVEL400", "해당 여행은 이미 종료되었습니다."),
+    INVALID_TRAVEL_USER(HttpStatus.UNAUTHORIZED, "TRAVEL_USER401", "해당 유저는 여행기를 수정할 권한이 없습니다."),
 
     // 요청 정보를 가지고 올 수 없을 때
     REQUEST_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "REQUEST404", "요청 정보를 가져올 수 없습니다."),

--- a/src/main/java/umc/TripPiece/converter/TravelConverter.java
+++ b/src/main/java/umc/TripPiece/converter/TravelConverter.java
@@ -128,4 +128,14 @@ public class TravelConverter {
                 .build();
     }
 
+    public static TravelResponseDto.UpdateResponseDto toUpdateResponseDto(Travel travel) {
+        return TravelResponseDto.UpdateResponseDto.builder()
+                .title(travel.getTitle())
+                .pictureUrl(travel.getThumbnail())
+                .startDate(travel.getStartDate().toLocalDate())
+                .endDate(travel.getEndDate().toLocalDate())
+                .build();
+
+    }
+
 }

--- a/src/main/java/umc/TripPiece/domain/Travel.java
+++ b/src/main/java/umc/TripPiece/domain/Travel.java
@@ -35,9 +35,12 @@ public class Travel extends BaseEntity {
     @JoinColumn(name = "city_id")
     private City city;
 
+    @Setter
     private String title;
     private String description;
+    @Setter
     private LocalDateTime startDate;
+    @Setter
     private LocalDateTime endDate;
     private boolean travelOpen;
     private Long likeCount;

--- a/src/main/java/umc/TripPiece/service/TravelService.java
+++ b/src/main/java/umc/TripPiece/service/TravelService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import umc.TripPiece.apiPayload.code.status.ErrorStatus;
+import umc.TripPiece.apiPayload.exception.GeneralException;
 import umc.TripPiece.apiPayload.exception.handler.BadRequestHandler;
 import umc.TripPiece.apiPayload.exception.handler.NotFoundHandler;
 import umc.TripPiece.aws.s3.AmazonS3Manager;
@@ -46,6 +47,7 @@ import umc.TripPiece.security.SecurityUtils;
 import umc.TripPiece.web.dto.request.TravelRequestDto;
 import umc.TripPiece.web.dto.request.TravelRequestDto.EmojiDto;
 import umc.TripPiece.web.dto.request.TravelRequestDto.MemoDto;
+import umc.TripPiece.web.dto.request.TravelRequestDto.UpdateRequestDto;
 import umc.TripPiece.web.dto.response.TravelResponseDto;
 
 @Service
@@ -520,6 +522,47 @@ public class TravelService {
                 .filter(Objects::nonNull)
                 .map(TravelConverter::toUpdatablePictureDto)
                 .toList();
+    }
+
+    @Transactional
+    public TravelResponseDto.UpdateResponseDto updateTravel(Long travelId, TravelRequestDto.UpdateRequestDto request) {
+        Travel travel = travelRepository.findById(travelId).get();
+        Long userId = SecurityUtils.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+
+        if (!travel.getUser().equals(user)) {
+            throw new BadRequestHandler(ErrorStatus.INVALID_TRAVEL_USER);
+        }
+
+        if (request.getThumbnail() != null) {
+            String originThumbnail = travel.getThumbnail();
+
+            if (originThumbnail != null) {
+                s3Manager.deleteFile(originThumbnail);
+            }
+
+            // UUID 생성
+            String uuid = UUID.randomUUID().toString();
+
+            // 동영상 저장
+            String newThumbnail = s3Manager.uploadFile("thumbnails/" + uuid, request.getThumbnail(), Category.PICTURE);
+            travel.setThumbnail(newThumbnail);
+        }
+
+        if (request.getStartDate() != null) {
+            travel.setStartDate(request.getStartDate().atStartOfDay());
+        }
+
+        if (request.getEndDate() != null) {
+            travel.setEndDate(request.getEndDate().atStartOfDay());
+        }
+
+        if (request.getTitle() != null) {
+            travel.setTitle(request.getTitle());
+        }
+
+        return TravelConverter.toUpdateResponseDto(travel);
     }
 
     private void initPicturesThumbnail(Travel travel) {

--- a/src/main/java/umc/TripPiece/web/controller/TravelController.java
+++ b/src/main/java/umc/TripPiece/web/controller/TravelController.java
@@ -19,6 +19,7 @@ import umc.TripPiece.web.dto.request.TravelRequestDto;
 import umc.TripPiece.web.dto.response.TravelResponseDto;
 
 import java.util.List;
+import umc.TripPiece.web.dto.response.TravelResponseDto.UpdateResponseDto;
 
 @Tag(name = "Travel", description = "여행기 관련 API")
 @RestController
@@ -170,6 +171,17 @@ public class TravelController {
             @PathVariable("travelId") Long travelId,
             @RequestParam(name = "pictureIdList") List<Long> pictureIdList) {
         List<TravelResponseDto.UpdatablePictureDto> response = travelService.updateThumbnail(travelId, pictureIdList);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PatchMapping(value = "/mytravels/{travelId}", consumes = "multipart/form-data")
+    @Operation(summary = "여행기 편집(썸네일, 기간, 제목) API", description = "여행기의 썸네일, 제목, 기간을 수정")
+    public ApiResponse<TravelResponseDto.UpdateResponseDto> updateTravel(
+            @ExistEntity(entityType = umc.TripPiece.domain.Travel.class)
+            @PathVariable("travelId") Long travelId,
+            @Valid @ModelAttribute TravelRequestDto.UpdateRequestDto request
+    ) {
+        TravelResponseDto.UpdateResponseDto response = travelService.updateTravel(travelId, request);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/umc/TripPiece/web/dto/request/TravelRequestDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/request/TravelRequestDto.java
@@ -1,5 +1,6 @@
 package umc.TripPiece.web.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -9,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 public class TravelRequestDto {
 
@@ -38,6 +41,18 @@ public class TravelRequestDto {
 
         @NotBlank
         String description;
+    }
+
+    @Getter
+    @Setter
+    public static class UpdateRequestDto {
+        private MultipartFile thumbnail;
+        @Size(max = 15, message = "제목은 15자 이내")
+        private String title;
+        @Schema(description = "yyyy-mm-dd")
+        private LocalDate startDate;
+        @Schema(description = "yyyy-mm-dd")
+        private LocalDate endDate;
     }
 
 }

--- a/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
+++ b/src/main/java/umc/TripPiece/web/dto/response/TravelResponseDto.java
@@ -116,4 +116,15 @@ public class TravelResponseDto {
         Boolean travel_thumbnail;
         Integer thumbnail_index;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateResponseDto {
+        private String pictureUrl;
+        private String title;
+        private LocalDate startDate;
+        private LocalDate endDate;
+    }
 }


### PR DESCRIPTION
## 연관 이슈

close #133 

<br/>

## 개요

여행기 편집 API 구현

<br/>

## ✅ 작업 내용

- 에러 코드 추가(해당 여행기 소유자가 아닌 유저가 수정 시도 시)
- 여행기 편집 API 구현(Patch)

<img width="261" alt="image" src="https://github.com/user-attachments/assets/2f412210-cbd2-4882-9274-5d4696f0efb7" />


<br/>

